### PR TITLE
TST: Update for latest pysat testing updates

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,0 @@
-[report]
-omit =
-  */instruments/templates/

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,4 @@ script:
  - pytest -vs --cov=pysatMadrigal/ --flake8
 
 after_success:
- - coveralls
+ - coveralls --rcfile=setup.cfg

--- a/pysatMadrigal/tests/test_instruments.py
+++ b/pysatMadrigal/tests/test_instruments.py
@@ -26,6 +26,11 @@ for method in method_list:
             mark = pytest.mark.parametrize("inst", instruments['no_download'])
             getattr(InstTestClass, method).pytestmark.append(mark)
 
+# remote_file_list not functional in current code.  Disabling for now
+if 'test_remote_file_list' in method_list:
+    mark = pytest.mark.skip(reason="not currently implemented")
+    getattr(InstTestClass, 'test_remote_file_list').pytestmark.append(mark)
+
 
 class TestInstruments(InstTestClass):
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[coverage:report]
+omit =
+  */instruments/templates/
+
 [tool:pytest]
 markers =
     all_inst: tests all instruments


### PR DESCRIPTION
The instrument tests inherited from pysat have been updated with new tests.  Adding skip notation to these until #5 is sorted out.

Also, update setup.cfg to consolidate settings, as in pysat.