### PR TITLE
MAINT: use inst_id

### DIFF
--- a/pysatMadrigal/instruments/dmsp_ivm.py
+++ b/pysatMadrigal/instruments/dmsp_ivm.py
@@ -26,7 +26,7 @@ name
     'ivm'
 tag
     'utd', None
-sat_id
+inst_id
     ['f11', 'f12', 'f13', 'f14', 'f15', 'f16', 'f17', 'f18']
 
 Example
@@ -72,9 +72,9 @@ logger = logging.getLogger(__name__)
 platform = 'dmsp'
 name = 'ivm'
 tags = {'utd': 'UTDallas DMSP data processing', '': 'Level 2 data processing'}
-sat_ids = {'f11': ['utd', ''], 'f12': ['utd', ''], 'f13': ['utd', ''],
-           'f14': ['utd', ''], 'f15': ['utd', ''], 'f16': [''], 'f17': [''],
-           'f18': ['']}
+inst_ids = {'f11': ['utd', ''], 'f12': ['utd', ''], 'f13': ['utd', ''],
+            'f14': ['utd', ''], 'f15': ['utd', ''], 'f16': [''], 'f17': [''],
+            'f18': ['']}
 _test_dates = {'f11': {'utd': dt.datetime(1998, 1, 2)},
                'f12': {'utd': dt.datetime(1998, 1, 2)},
                'f13': {'utd': dt.datetime(1998, 1, 2)},
@@ -88,7 +88,7 @@ dmsp_fname1 = {'utd': 'dms_ut_{year:4d}{month:02d}{day:02d}_',
                '': 'dms_{year:4d}{month:02d}{day:02d}_'}
 dmsp_fname2 = {'utd': '.{version:03d}.hdf5', '': 's?.{version:03d}.hdf5'}
 supported_tags = {ss: {kk: dmsp_fname1[kk] + ss[1:] + dmsp_fname2[kk]
-                       for kk in sat_ids[ss]} for ss in sat_ids.keys()}
+                       for kk in inst_ids[ss]} for ss in inst_ids.keys()}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
@@ -135,7 +135,7 @@ def init(self):
     return
 
 
-def download(date_array, tag='', sat_id='', data_path=None, user=None,
+def download(date_array, tag='', inst_id='', data_path=None, user=None,
              password=None):
     """Downloads data from Madrigal.
 
@@ -147,7 +147,7 @@ def download(date_array, tag='', sat_id='', data_path=None, user=None,
     tag : string
         Tag identifier used for particular dataset. This input is provided by
         pysat. (default='')
-    sat_id : string
+    inst_id : string
         Satellite ID string identifier used for particular dataset. This input
         is provided by pysat. (default='')
     data_path : string
@@ -172,7 +172,7 @@ def download(date_array, tag='', sat_id='', data_path=None, user=None,
 
     """
     mad_meth.download(date_array, inst_code=str(madrigal_inst_code),
-                      kindat=str(madrigal_tag[sat_id][tag]),
+                      kindat=str(madrigal_tag[inst_id][tag]),
                       data_path=data_path, user=user, password=password)
 
 
@@ -272,7 +272,7 @@ def update_DMSP_ephemeris(inst, ephem=None):
         inst.data = pds.DataFrame(None)
         return
 
-    if ephem.sat_id != inst.sat_id:
+    if ephem.inst_id != inst.inst_id:
         raise ValueError('ephemera provided for the wrong satellite')
 
     if ephem.date != inst.date:

--- a/pysatMadrigal/instruments/jro_isr.py
+++ b/pysatMadrigal/instruments/jro_isr.py
@@ -55,7 +55,7 @@ tags = {'drifts': 'Drifts and wind', 'drifts_ave': 'Averaged drifts',
         'oblique_stan': 'Standard Faraday rotation double-pulse',
         'oblique_rand': 'Randomized Faraday rotation double-pulse',
         'oblique_long': 'Long pulse Faraday rotation'}
-sat_ids = {'': list(tags.keys())}
+inst_ids = {'': list(tags.keys())}
 _test_dates = {'': {'drifts': dt.datetime(2010, 1, 19),
                     'drifts_ave': dt.datetime(2010, 1, 19),
                     'oblique_stan': dt.datetime(2010, 4, 19),
@@ -72,7 +72,7 @@ supported_tags = {ss: {'drifts': jro_fname1 + "drifts" + jro_fname2,
                        'oblique_stan': jro_fname1 + jro_fname2,
                        'oblique_rand': jro_fname1 + "?" + jro_fname2,
                        'oblique_long': jro_fname1 + "?" + jro_fname2}
-                  for ss in sat_ids.keys()}
+                  for ss in inst_ids.keys()}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
@@ -123,7 +123,7 @@ def init(self):
     return
 
 
-def download(date_array, tag='', sat_id='', data_path=None, user=None,
+def download(date_array, tag='', inst_id='', data_path=None, user=None,
              password=None):
     """Downloads data from Madrigal.
 
@@ -135,7 +135,7 @@ def download(date_array, tag='', sat_id='', data_path=None, user=None,
     tag : string
         Tag identifier used for particular dataset. This input is provided by
         pysat. (default='')
-    sat_id : string
+    inst_id : string
         Satellite ID string identifier used for particular dataset. This input
         is provided by pysat. (default='')
     data_path : string
@@ -160,7 +160,7 @@ def download(date_array, tag='', sat_id='', data_path=None, user=None,
 
     """
     mad_meth.download(date_array, inst_code=str(madrigal_inst_code),
-                      kindat=str(madrigal_tag[sat_id][tag]),
+                      kindat=str(madrigal_tag[inst_id][tag]),
                       data_path=data_path, user=user, password=password)
 
 

--- a/pysatMadrigal/instruments/methods/madrigal.py
+++ b/pysatMadrigal/instruments/methods/madrigal.py
@@ -37,7 +37,7 @@ def cedar_rules():
 
 
 # support load routine
-def load(fnames, tag=None, sat_id=None, xarray_coords=[]):
+def load(fnames, tag=None, inst_id=None, xarray_coords=[]):
     """Loads data from Madrigal into Pandas.
 
     This routine is called as needed by pysat. It is not intended
@@ -53,7 +53,7 @@ def load(fnames, tag=None, sat_id=None, xarray_coords=[]):
         This input is nominally provided by pysat itself. While
         tag defaults to None here, pysat provides '' as the default
         tag unless specified by user at Instrument instantiation. (default='')
-    sat_id : string
+    inst_id : string
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself. (default='')
     xarray_coords : list
@@ -392,7 +392,7 @@ def good_exp(exp, date_array=None):
     return gflag
 
 
-def list_remote_files(tag, sat_id, inst_code=None, kindat=None, user=None,
+def list_remote_files(tag, inst_id, inst_code=None, kindat=None, user=None,
                       password=None, supported_tags=None,
                       url="http://cedar.openmadrigal.org",
                       two_digit_year_break=None, start=dt.datetime(1900, 1, 1),
@@ -404,7 +404,7 @@ def list_remote_files(tag, sat_id, inst_code=None, kindat=None, user=None,
     tag : string or NoneType
         Denotes type of file to load.  Accepted types are <tag strings>.
         (default=None)
-    sat_id : string or NoneType
+    inst_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
     inst_code : string
@@ -423,7 +423,7 @@ def list_remote_files(tag, sat_id, inst_code=None, kindat=None, user=None,
     password : string
         Password for data download. (default=None)
     supported_tags : dict or NoneType
-        keys are sat_id, each containing a dict keyed by tag
+        keys are inst_id, each containing a dict keyed by tag
         where the values file format template strings. (default=None)
     url : string
         URL for Madrigal site (default='http://cedar.openmadrigal.org')
@@ -474,7 +474,7 @@ def list_remote_files(tag, sat_id, inst_code=None, kindat=None, user=None,
 
     # Test input
     try:
-        format_str = supported_tags[sat_id][tag]
+        format_str = supported_tags[inst_id][tag]
     except KeyError:
         raise ValueError('Problem parsing supported_tags')
 

--- a/pysatMadrigal/instruments/templates/madrigal_pandas.py
+++ b/pysatMadrigal/instruments/templates/madrigal_pandas.py
@@ -88,7 +88,7 @@ logger = logging.getLogger(__name__)
 platform = 'madrigal'
 name = 'pandas'
 tags = {'': 'General Madrigal data access loaded into pysat via pandas.'}
-sat_ids = {'': list(tags.keys())}
+inst_ids = {'': list(tags.keys())}
 # need to sort out test day setting for unit testing
 _test_dates = {'': {'': dt.datetime(2010, 1, 19)}}
 
@@ -98,7 +98,7 @@ _test_dates = {'': {'': dt.datetime(2010, 1, 19)}}
 jro_fname1 = '*{year:4d}{month:02d}{day:02d}'
 jro_fname2 = '.{version:03d}.hdf5'
 supported_tags = {ss: {'': '*'.join((jro_fname1, jro_fname2))}
-                  for ss in sat_ids.keys()}
+                  for ss in inst_ids.keys()}
 list_files = functools.partial(cdw.list_files,
                                supported_tags=supported_tags)
 
@@ -134,7 +134,7 @@ def init(self):
     return
 
 
-def _general_download(date_array, tag='', sat_id='', data_path=None, user=None,
+def _general_download(date_array, tag='', inst_id='', data_path=None, user=None,
                       password=None, inst_code=None, kindat=None):
     """Downloads data from Madrigal.
 
@@ -152,7 +152,7 @@ def _general_download(date_array, tag='', sat_id='', data_path=None, user=None,
     tag : string
         Tag identifier used for particular dataset. This input is provided by
         pysat. (default='')
-    sat_id : string
+    inst_id : string
         Satellite ID string identifier used for particular dataset. This input
         is provided by pysat. (default='')
     data_path : string


### PR DESCRIPTION
Addresses pysat/pysat#473, test with pysat/pysat#556

Updates use of `sat_id` to `inst_id`.

Passing locally with the `break/inst_id` branch of pysat.  Expected to fail on Travis until pysat/pysat#556 is merged.