### PR TITLE
TST: support user / password info in unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - pip install pytest-flake8
   - pip install madrigalWeb
   - pip install PyForecastTools
-  - pip install pysatCDF >/dev/null
+  - pip install portalocker
   # Custom pysat install
   - cd ..
   - git clone --single-branch --branch develop-3 https://github.com/pysat/pysat.git

--- a/pysatMadrigal/instruments/methods/madrigal.py
+++ b/pysatMadrigal/instruments/methods/madrigal.py
@@ -648,7 +648,7 @@ def _check_madrigal_params(inst_code, user, password):
     """Checks that parameters requried by Madrigal database are passed through.
     Default values of None will raise an error.
 
-    inst_code : string
+    inst_code : str
         Madrigal instrument code(s), cast as a string.  If multiple are used,
         separate them with commas.
     user : str

--- a/pysatMadrigal/instruments/methods/madrigal.py
+++ b/pysatMadrigal/instruments/methods/madrigal.py
@@ -338,17 +338,6 @@ def download(date_array, inst_code=None, kindat=None, data_path=None,
     if kindat is None:
         raise ValueError("Must supply Madrigal experiment code")
 
-    # currently passes things along if no user and password supplied
-    # need to do this for testing
-    # TODO, implement user and password values in test code
-    # specific to each instrument
-    if user is None:
-        logger.info('No user information supplied for download.')
-        user = 'pysat_testing'
-    if password is None:
-        logger.info('Please provide email address in password field.')
-        password = 'pysat_testing@not_real_email.org'
-
     # Initialize the connection to Madrigal
     web_data = madrigalWeb.MadrigalData(url)
 
@@ -436,17 +425,6 @@ def get_remote_filenames(inst_code=None, kindat=None, user=None,
         kindat = []
     else:
         kindat = [int(kk) for kk in kindat.split(",")]
-
-    # currently passes things along if no user and password supplied
-    # need to do this for testing
-    # TODO, implement user and password values in test code
-    # specific to each instrument
-    if user is None:
-        logger.warning('No user information supplied for download.')
-        user = 'pysat_testing'
-    if password is None:
-        logger.warning('Please provide email address in password field.')
-        password = 'pysat_testing@not_real_email.org'
 
     # If date_array supplied, overwrite start and stop
     if date_array is not None:
@@ -592,17 +570,6 @@ def list_remote_files(tag, inst_id, inst_code=None, kindat=None, user=None,
     """
     if inst_code is None:
         raise ValueError("Must supply Madrigal instrument code")
-
-    # currently passes things along if no user and password supplied
-    # need to do this for testing
-    # TODO, implement user and password values in test code
-    # specific to each instrument
-    if user is None:
-        logger.info('No user information supplied for download.')
-        user = 'pysat_testing'
-    if password is None:
-        logger.info('Please provide email address in password field.')
-        password = 'pysat_testing@not_real_email.org'
 
     # Test input
     try:

--- a/pysatMadrigal/instruments/methods/madrigal.py
+++ b/pysatMadrigal/instruments/methods/madrigal.py
@@ -332,8 +332,7 @@ def download(date_array, inst_code=None, kindat=None, data_path=None,
         raise ValueError("Unknown file format {:}, accepts {:}".format(
             file_type, file_types))
 
-    if inst_code is None:
-        raise ValueError("Must supply Madrigal instrument code")
+    _check_madrigal_params(inst_code=inst_code, user=user, password=password)
 
     if kindat is None:
         raise ValueError("Must supply Madrigal experiment code")
@@ -418,8 +417,7 @@ def get_remote_filenames(inst_code=None, kindat=None, user=None,
 
     """
 
-    if inst_code is None:
-        raise ValueError("Must supply Madrigal instrument code")
+    _check_madrigal_params(inst_code=inst_code, user=user, password=password)
 
     if kindat is None:
         kindat = []
@@ -568,8 +566,8 @@ def list_remote_files(tag, inst_id, inst_code=None, kindat=None, user=None,
                                               inst_code=madrigal_inst_code)
 
     """
-    if inst_code is None:
-        raise ValueError("Must supply Madrigal instrument code")
+
+    _check_madrigal_params(inst_code=inst_code, user=user, password=password)
 
     # Test input
     try:
@@ -644,3 +642,29 @@ def filter_data_single_date(inst):
         inst.data = inst[idx]
 
     return
+
+
+def _check_madrigal_params(inst_code, user, password):
+    """Checks that parameters requried by Madrigal database are passed through.
+    Default values of None will raise an error.
+
+    inst_code : string
+        Madrigal instrument code(s), cast as a string.  If multiple are used,
+        separate them with commas. (default=None)
+    user : str
+        The user's names should be provided in field user. Ruby Payne-Scott
+        should be entered as Ruby+Payne-Scott
+    password : str
+        The password field should be the user's email address. These parameters
+            are passed to Madrigal when downloading.
+    """
+
+    if inst_code is None:
+        raise ValueError("Must supply Madrigal instrument code")
+
+    if not (isinstance(user, str) and isinstance(password, str)):
+        raise ValueError(' '.join(("The madrigal database requries a username",
+                                   "and password.  Please input these as",
+                                   "user='firstname+lastname' and",
+                                   "password='myname@email.address' in this",
+                                   "function.")))

--- a/pysatMadrigal/instruments/methods/madrigal.py
+++ b/pysatMadrigal/instruments/methods/madrigal.py
@@ -650,7 +650,7 @@ def _check_madrigal_params(inst_code, user, password):
 
     inst_code : string
         Madrigal instrument code(s), cast as a string.  If multiple are used,
-        separate them with commas. (default=None)
+        separate them with commas.
     user : str
         The user's names should be provided in field user. Ruby Payne-Scott
         should be entered as Ruby+Payne-Scott

--- a/pysatMadrigal/tests/test_general_methods.py
+++ b/pysatMadrigal/tests/test_general_methods.py
@@ -1,0 +1,33 @@
+import pytest
+from pysatMadrigal.instruments.methods import madrigal as pm_meth
+
+
+class TestBasic():
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup."""
+        self.kwargs = {'inst_code': 'inst_code',
+                       'user': 'username',
+                       'password': 'password'}
+
+    def cleanup(self):
+        """Runs after every method to clean up previous testing."""
+        del self.kwargs
+
+    @pytest.mark.parametrize("del_val",
+                             ['inst_code', 'user', 'password'])
+    def test_check_madrigal_params_no_input(self, del_val):
+        """Test that an error is thrown if None is passed through"""
+        self.kwargs[del_val] = None
+
+        with pytest.raises(ValueError):
+            pm_meth._check_madrigal_params(**self.kwargs)
+
+    @pytest.mark.parametrize("del_val",
+                             ['user', 'password'])
+    def test_check_madrigal_params_bad_input(self, del_val):
+        """Test that an error is thrown if non-string is passed through"""
+        self.kwargs[del_val] = 17
+
+        with pytest.raises(ValueError):
+            pm_meth._check_madrigal_params(**self.kwargs)

--- a/pysatMadrigal/tests/test_instruments.py
+++ b/pysatMadrigal/tests/test_instruments.py
@@ -7,7 +7,23 @@ from pysat.tests.instrument_test_class import InstTestClass
 
 import pysatMadrigal
 
-instruments = generate_instrument_list(inst_loc=pysatMadrigal.instruments)
+# Optional code to pass through user and password info to test instruments
+# dict, keyed by pysat instrument, with a list of usernames and passwords
+# user_info = {'platform_name': {'user': 'pysat_user',
+#                                'password': 'None'}}
+user_info = {module: {'user': 'pysat+CI_tests',
+                      'password': 'pysat.developers@gmail.com'}
+             for module in pysatMadrigal.instruments.__all__}
+
+# Developers for instrument libraries should update the following line to
+# point to their own subpackage location
+# e.g.,
+# instruments = generate_instrument_list(inst_loc=mypackage.inst)
+# If user and password info supplied, use the following instead
+# instruments = generate_instrument_list(inst_loc=mypackage.inst,
+#                                        user_info=user_info)
+instruments = generate_instrument_list(inst_loc=pysatMadrigal.instruments,
+                                       user_info=user_info)
 method_list = [func for func in dir(InstTestClass)
                if callable(getattr(InstTestClass, func))]
 


### PR DESCRIPTION
This PR works in conjunction with pysat/pysat#623.  Allows user and email to be passed through the instruments in test_instruments.py for Madrigal database.  Removes auto-generation of test values in the instrument methods.

Note this is expected to fail on Travis until changes at pysat are merged into develop-3.  Passes locally with the pysat test branch.