### PR TITLE
MAINT: remove unused kwarg

### DIFF
--- a/pysatMadrigal/instruments/dmsp_ivm.py
+++ b/pysatMadrigal/instruments/dmsp_ivm.py
@@ -189,9 +189,7 @@ load = mad_meth.load
 
 
 def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
-               supported_tags=supported_tags,
-               fake_daily_files_from_monthly=False, delimiter=None,
-               file_type='hdf5'):
+               supported_tags=supported_tags, delimiter=None, file_type='hdf5'):
     """Return a Pandas Series of every data file for this Instrument
 
     Parameters
@@ -211,11 +209,6 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
     supported_tags : dict or NoneType
         keys are inst_id, each containing a dict keyed by tag
         where the values file format template strings. (default=None)
-    fake_daily_files_from_monthly : bool
-        Some CDAWeb instrument data files are stored by month, interfering
-        with pysat's functionality of loading by day. This flag, when true,
-        appends daily dates to monthly files internally. These dates are
-        used by load routine in this module to provide data by day.
     delimiter : string
         Delimiter string upon which files will be split (e.g., '.')
     file_type : string
@@ -233,11 +226,9 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
         supported_tags[inst_id][tag] = supported_tags[inst_id][tag].format(
             file_type=file_type)
 
-    out = ps_gen.list_files(
-        tag=tag, inst_id=inst_id, data_path=data_path, format_str=format_str,
-        supported_tags=supported_tags,
-        fake_daily_files_from_monthly=fake_daily_files_from_monthly,
-        delimiter=delimiter)
+    out = ps_gen.list_files(tag=tag, inst_id=inst_id, data_path=data_path,
+                            format_str=format_str, delimiter=delimiter,
+                            supported_tags=supported_tags)
 
     return out
 

--- a/pysatMadrigal/instruments/gnss_tec.py
+++ b/pysatMadrigal/instruments/gnss_tec.py
@@ -143,8 +143,7 @@ list_remote_files = functools.partial(mad_meth.list_remote_files,
 
 
 def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
-               supported_tags=supported_tags,
-               fake_daily_files_from_monthly=False, two_digit_year_break=99,
+               supported_tags=supported_tags, two_digit_year_break=99,
                delimiter=None, file_type='netCDF4'):
     """Return a Pandas Series of every data file for this Instrument
 
@@ -165,11 +164,6 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
     supported_tags : dict or NoneType
         keys are inst_id, each containing a dict keyed by tag
         where the values file format template strings. (default=None)
-    fake_daily_files_from_monthly : bool
-        Some CDAWeb instrument data files are stored by month, interfering
-        with pysat's functionality of loading by day. This flag, when true,
-        appends daily dates to monthly files internally. These dates are
-        used by load routine in this module to provide data by day.
     two_digit_year_break : int
         If filenames only store two digits for the year, then
         '1900' will be added for years >= two_digit_year_break
@@ -191,11 +185,10 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
         supported_tags[inst_id][tag] = supported_tags[inst_id][tag].format(
             file_type=file_type)
 
-    out = ps_gen.list_files(
-        tag=tag, inst_id=inst_id, data_path=data_path, format_str=format_str,
-        supported_tags=supported_tags,
-        fake_daily_files_from_monthly=fake_daily_files_from_monthly,
-        two_digit_year_break=two_digit_year_break, delimiter=delimiter)
+    out = ps_gen.list_files(tag=tag, inst_id=inst_id, data_path=data_path,
+                            format_str=format_str, delimiter=delimiter,
+                            supported_tags=supported_tags,
+                            two_digit_year_break=two_digit_year_break)
 
     return out
 

--- a/pysatMadrigal/instruments/jro_isr.py
+++ b/pysatMadrigal/instruments/jro_isr.py
@@ -170,9 +170,7 @@ list_remote_files = functools.partial(mad_meth.list_remote_files,
 
 
 def list_files(tag='', inst_id='', data_path=None, format_str=None,
-               supported_tags=supported_tags,
-               fake_daily_files_from_monthly=False,
-               delimiter=None, file_type='hdf5'):
+               supported_tags=supported_tags, delimiter=None, file_type='hdf5'):
     """Return a Pandas Series of every data file for this Instrument
 
     Parameters
@@ -192,11 +190,6 @@ def list_files(tag='', inst_id='', data_path=None, format_str=None,
     supported_tags : dict or NoneType
         keys are inst_id, each containing a dict keyed by tag
         where the values file format template strings. (default=None)
-    fake_daily_files_from_monthly : bool
-        Some CDAWeb instrument data files are stored by month, interfering
-        with pysat's functionality of loading by day. This flag, when true,
-        appends daily dates to monthly files internally. These dates are
-        used by load routine in this module to provide data by day.
     delimiter : string
         Delimiter string upon which files will be split (e.g., '.')
     file_type : string
@@ -214,11 +207,9 @@ def list_files(tag='', inst_id='', data_path=None, format_str=None,
         supported_tags[inst_id][tag] = supported_tags[inst_id][tag].format(
             file_type=file_type)
 
-    out = ps_gen.list_files(
-        tag=tag, inst_id=inst_id, data_path=data_path, format_str=format_str,
-        supported_tags=supported_tags,
-        fake_daily_files_from_monthly=fake_daily_files_from_monthly,
-        delimiter=delimiter)
+    out = ps_gen.list_files(tag=tag, inst_id=inst_id, data_path=data_path,
+                            format_str=format_str,
+                            supported_tags=supported_tags, delimiter=delimiter)
 
     return out
 

--- a/pysatMadrigal/instruments/jro_isr.py
+++ b/pysatMadrigal/instruments/jro_isr.py
@@ -90,7 +90,7 @@ _test_dates = {'': {'drifts': dt.datetime(2010, 1, 19),
 # To ensure this function is always applied first, we set the filter
 # function as the default function for (JRO).
 # Default function is run first by the nanokernel on every load call.
-default = mad_meth.filter_data_single_date
+preprocess = mad_meth.filter_data_single_date
 
 
 def init(self):


### PR DESCRIPTION
Removed unused kwarg `fake_daily_files_from_monthly` from `list_files` routine in all instruments.