### PR TITLE
Fixed bug in remote file listing method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.?.?] - 2020-07-03
-- Added coords from pysat.utils
+## [0.0.4] - TBD
 - Made changes to structure to comply with updates in pysat 3.0.0
+- Enhancements
+  - Added coords from pysat.utils
+  - Added Vertical TEC Instrument
 - Bug Fix
-   - Updated madrigal methods to simplify compound data types and enable
-     creation of netCDF4 files using `Instrument.to_netcdf4()`.
-   - Updated load for multiple files in pandas format
+  - Updated madrigal methods to simplify compound data types and enable
+    creation of netCDF4 files using `Instrument.to_netcdf4()`.
+  - Updated load for multiple files in pandas format
+  - Fixed remote listing routine to return filenames instead of experiments
 
 ## [0.0.3] - 2020-06-15
 - pypi compatibility

--- a/pysatMadrigal/instruments/dmsp_ivm.py
+++ b/pysatMadrigal/instruments/dmsp_ivm.py
@@ -41,7 +41,7 @@ Example
 
 Note
 ----
-    Please provide name and email when downloading data with this routine.
+Please provide name and email when downloading data with this routine.
 
 Code development supported by NSF grant 1259508
 
@@ -87,26 +87,32 @@ dmsp_fname2 = {'utd': '.{{version:03d}}.{file_type}',
                '': 's?.{{version:03d}}.{file_type}'}
 supported_tags = {ss: {kk: dmsp_fname1[kk] + ss[1:] + dmsp_fname2[kk]
                        for kk in inst_ids[ss]} for ss in inst_ids.keys()}
+remote_tags = {ss: {kk: supported_tags[ss][kk].format(file_type='hdf5')
+                    for kk in inst_ids[ss]} for ss in inst_ids.keys()}
 
-# madrigal tags
+# Madrigal tags
 madrigal_inst_code = 8100
-madrigal_tag = {'f11': {'utd': 10241, '': 10111},
-                'f12': {'utd': 10242, '': 10112},
-                'f13': {'utd': 10243, '': 10113},
-                'f14': {'utd': 10244, '': 10114},
-                'f15': {'utd': 10245, '': 10115},
-                'f16': {'': 10116},
-                'f17': {'': 10117},
-                'f18': {'': 10118}, }
+madrigal_tag = {'f11': {'utd': '10241', '': '10111'},
+                'f12': {'utd': '10242', '': '10112'},
+                'f13': {'utd': '10243', '': '10113'},
+                'f14': {'utd': '10244', '': '10114'},
+                'f15': {'utd': '10245', '': '10115'},
+                'f16': {'': '10116'},
+                'f17': {'': '10117'},
+                'f18': {'': '10118'}, }
 
 # ----------------------------------------------------------------------------
 # Instrument test attributes
 
-_test_dates = {'f11': {'utd': dt.datetime(1998, 1, 2)},
-               'f12': {'utd': dt.datetime(1998, 1, 2)},
-               'f13': {'utd': dt.datetime(1998, 1, 2)},
-               'f14': {'utd': dt.datetime(1998, 1, 2)},
-               'f15': {'utd': dt.datetime(2017, 12, 30)}}
+_test_dates = {
+    'f11': {tag: dt.datetime(1998, 1, 2) for tag in inst_ids['f11']},
+    'f12': {tag: dt.datetime(1998, 1, 2) for tag in inst_ids['f12']},
+    'f13': {tag: dt.datetime(1998, 1, 2) for tag in inst_ids['f13']},
+    'f14': {tag: dt.datetime(1998, 1, 2) for tag in inst_ids['f14']},
+    'f15': {tag: dt.datetime(2017, 12, 30) for tag in inst_ids['f15']},
+    'f16': {tag: dt.datetime(2009, 1, 1) for tag in inst_ids['f16']},
+    'f17': {tag: dt.datetime(2009, 1, 1) for tag in inst_ids['f17']},
+    'f18': {tag: dt.datetime(2017, 12, 30) for tag in inst_ids['f18']}}
 
 # ----------------------------------------------------------------------------
 # Instrument methods
@@ -181,8 +187,9 @@ def clean(self):
 
 # Set the list_remote_files routine
 list_remote_files = functools.partial(mad_meth.list_remote_files,
-                                      supported_tags=supported_tags,
-                                      inst_code=madrigal_inst_code)
+                                      inst_code=madrigal_inst_code,
+                                      kindats=madrigal_tag,
+                                      supported_tags=remote_tags)
 
 # Set the load routine
 load = mad_meth.load
@@ -274,7 +281,7 @@ def download(date_array, tag='', inst_id='', data_path=None, user=None,
 
     """
     mad_meth.download(date_array, inst_code=str(madrigal_inst_code),
-                      kindat=str(madrigal_tag[inst_id][tag]),
+                      kindat=madrigal_tag[inst_id][tag],
                       data_path=data_path, user=user, password=password)
     return
 

--- a/pysatMadrigal/instruments/gnss_tec.py
+++ b/pysatMadrigal/instruments/gnss_tec.py
@@ -61,10 +61,12 @@ vname = '.{{version:03d}}'
 supported_tags = {ss: {'vtec': ''.join(['gps', dname, 'g', vname,
                                         ".{file_type}"])}
                   for ss in inst_ids.keys()}
+remote_tags = {ss: {kk: supported_tags[ss][kk].format(file_type='hdf5')
+                    for kk in inst_ids[ss]} for ss in inst_ids.keys()}
 
 # madrigal tags
 madrigal_inst_code = 8000
-madrigal_tag = {'': {'vtec': 3500}}  # , 'los': 3505}}
+madrigal_tag = {'': {'vtec': '3500'}}  # , 'los': '3505'}}
 
 # ----------------------------------------------------------------------------
 # Instrument test attributes
@@ -138,8 +140,9 @@ def clean(self):
 
 # support listing files currently available on remote server (Madrigal)
 list_remote_files = functools.partial(mad_meth.list_remote_files,
-                                      supported_tags=supported_tags,
-                                      inst_code=madrigal_inst_code)
+                                      supported_tags=remote_tags,
+                                      inst_code=madrigal_inst_code,
+                                      kindats=madrigal_tag)
 
 
 def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
@@ -236,7 +239,7 @@ def download(date_array, tag='', inst_id='', data_path=None, user=None,
 
     """
     mad_meth.download(date_array, inst_code=str(madrigal_inst_code),
-                      kindat=str(madrigal_tag[inst_id][tag]),
+                      kindat=madrigal_tag[inst_id][tag],
                       data_path=data_path, user=user, password=password,
                       file_type=file_type, url=url)
 

--- a/pysatMadrigal/instruments/jro_isr.py
+++ b/pysatMadrigal/instruments/jro_isr.py
@@ -66,11 +66,14 @@ supported_tags = {ss: {'drifts': jro_fname1 + "drifts" + jro_fname2,
                        'oblique_rand': jro_fname1 + "?" + jro_fname2,
                        'oblique_long': jro_fname1 + "?" + jro_fname2}
                   for ss in inst_ids.keys()}
+remote_tags = {ss: {kk: supported_tags[ss][kk].format(file_type='hdf5')
+                    for kk in inst_ids[ss]} for ss in inst_ids.keys()}
 
 # Madrigal tags
 madrigal_inst_code = 10
-madrigal_tag = {'': {'drifts': 1910, 'drifts_ave': 1911, 'oblique_stan': 1800,
-                     'oblique_rand': 1801, 'oblique_long': 1802}, }
+madrigal_tag = {'': {'drifts': "1910", 'drifts_ave': "1911",
+                     'oblique_stan': "1800", 'oblique_rand': "1801",
+                     'oblique_long': "1802"}, }
 
 # ----------------------------------------------------------------------------
 # Instrument test attributes
@@ -165,8 +168,9 @@ def clean(self):
 
 # Set list_remote_files routine
 list_remote_files = functools.partial(mad_meth.list_remote_files,
-                                      supported_tags=supported_tags,
-                                      inst_code=madrigal_inst_code)
+                                      supported_tags=remote_tags,
+                                      inst_code=madrigal_inst_code,
+                                      kindats=madrigal_tag)
 
 
 def list_files(tag='', inst_id='', data_path=None, format_str=None,
@@ -254,7 +258,7 @@ def download(date_array, tag='', inst_id='', data_path=None, user=None,
 
     """
     mad_meth.download(date_array, inst_code=str(madrigal_inst_code),
-                      kindat=str(madrigal_tag[inst_id][tag]),
+                      kindat=madrigal_tag[inst_id][tag],
                       data_path=data_path, user=user, password=password,
                       file_type=file_type)
 

--- a/pysatMadrigal/instruments/methods/madrigal.py
+++ b/pysatMadrigal/instruments/methods/madrigal.py
@@ -5,18 +5,18 @@ pysat, reducing the amount of user intervention.
  """
 
 import datetime as dt
-import logging
 import numpy as np
 import os
 import pandas as pds
 import xarray as xr
 
 import h5py
-from madrigalWeb import madrigalWeb
-
 import pysat
 
-logger = logging.getLogger(__name__)
+from madrigalWeb import madrigalWeb
+
+
+logger = pysat.logger
 file_types = ['hdf5', 'netCDF4', 'simple']
 
 
@@ -370,8 +370,7 @@ def get_remote_filenames(inst_code=None, kindat=None, user=None,
                          url="http://cedar.openmadrigal.org",
                          start=dt.datetime(1900, 1, 1), stop=dt.datetime.now(),
                          date_array=None):
-    """Retrieve the remote filenames for a specified Madrigal instrument
-    (and experiment)
+    """Retrieve the remote filenames for a specified Madrigal experiment
 
     Parameters
     ----------
@@ -403,6 +402,11 @@ def get_remote_filenames(inst_code=None, kindat=None, user=None,
         Array of datetimes to download data for. The sequence of dates need not
         be contiguous and will be used instead of start and stop if supplied.
         (default=None)
+
+    Returns
+    -------
+    files : madrigalWeb.madrigalWeb.MadrigalExperimentFile
+        Madrigal file object that contains remote experiment file data
 
     Note
     ----
@@ -505,7 +509,7 @@ def list_remote_files(tag, inst_id, inst_code=None, kindat=None, user=None,
                       password=None, supported_tags=None,
                       url="http://cedar.openmadrigal.org",
                       two_digit_year_break=None, start=dt.datetime(1900, 1, 1),
-                      stop=dt.datetime.now()):
+                      stop=dt.datetime.utcnow()):
     """List files available from Madrigal.
 
     Parameters
@@ -545,6 +549,12 @@ def list_remote_files(tag, inst_id, inst_code=None, kindat=None, user=None,
     stop : dt.datetime
         Ending time for the file list (defaults to time of run)
 
+    Returns
+    -------
+    pds.Series
+        A series of filenames, see `pysat._files.process_parsed_filenames`
+        for more information.
+
     Note
     ----
     The user's names should be provided in field user. Ruby Payne-Scott should
@@ -576,16 +586,18 @@ def list_remote_files(tag, inst_id, inst_code=None, kindat=None, user=None,
     except KeyError:
         raise ValueError('Problem parsing supported_tags')
 
-    # Retrieve remote file list
+    # Retrieve remote file experiment list
     files = get_remote_filenames(inst_code=inst_code, kindat=kindat, user=user,
                                  password=password, url=url, start=start,
                                  stop=stop)
 
-    # parse these filenames to grab out the ones we want
-    logger.info("Parsing filenames")
-    stored = pysat._files.parse_fixed_width_filenames(files, format_str)
+    filenames = [file_exp.name for file_exp in files]
 
-    # process the parsed filenames and return a properly formatted Series
+    # Parse these filenames to grab out the ones we want
+    logger.info("Parsing filenames")
+    stored = pysat._files.parse_fixed_width_filenames(filenames, format_str)
+
+    # Process the parsed filenames and return a properly formatted Series
     logger.info("Processing filenames")
     return pysat._files.process_parsed_filenames(stored, two_digit_year_break)
 
@@ -613,7 +625,7 @@ def filter_data_single_date(inst):
     ::
 
         inst = pysat.Instrument()
-        inst.custom.attach(filter_data_single_date, 'modify')
+        inst.custom_attach(filter_data_single_date)
 
     This function will then be automatically applied to the
     Instrument object data on every load by the pysat nanokernel.
@@ -621,15 +633,13 @@ def filter_data_single_date(inst):
     Warnings
     --------
     For the best performance, this function should be added first in the queue.
-    This may be ensured by setting the default function in a
-    pysat instrument file to this one.
+    This may be ensured by setting the default function in a  pysat instrument
+    file to this one.
 
-    within platform_name.py set
+    To do this, within platform_name.py set `preprocess` at the top level.
     ::
 
-        default = pysat.instruments.methods.madrigal.filter_data_single_date
-
-    at the top level
+        preprocess = pysat.instruments.methods.madrigal.filter_data_single_date
 
     """
 
@@ -647,8 +657,9 @@ def filter_data_single_date(inst):
 
 def _check_madrigal_params(inst_code, user, password):
     """Checks that parameters requried by Madrigal database are passed through.
-    Default values of None will raise an error.
 
+    Parameters
+    ----------
     inst_code : str
         Madrigal instrument code(s), cast as a string.  If multiple are used,
         separate them with commas.
@@ -658,6 +669,12 @@ def _check_madrigal_params(inst_code, user, password):
     password : str
         The password field should be the user's email address. These parameters
             are passed to Madrigal when downloading.
+
+    Raises
+    ------
+    ValueError
+        Default values of None will raise an error.
+
     """
 
     if inst_code is None:
@@ -669,3 +686,5 @@ def _check_madrigal_params(inst_code, user, password):
                                    "user='firstname+lastname' and",
                                    "password='myname@email.address' in this",
                                    "function.")))
+
+    return

--- a/pysatMadrigal/instruments/templates/madrigal_pandas.py
+++ b/pysatMadrigal/instruments/templates/madrigal_pandas.py
@@ -76,7 +76,6 @@ Please provide name and email when downloading data with this routine.
 
 """
 
-import datetime as dt
 import functools
 
 from pysat.instruments.methods import general as ps_gen
@@ -89,8 +88,8 @@ from pysatMadrigal.instruments.methods import madrigal as mad_meth
 
 platform = 'madrigal'
 name = 'pandas'
-tags = {self.kwargs['kindat']: 'General pysat Madrigal data access.'}
-inst_ids = {self.kwargs['inst_code']: list(tags.keys())}
+tags = {'': 'General pysat Madrigal data access.'}
+inst_ids = {'': list(tags.keys())}
 
 pandas_format = True
 
@@ -131,8 +130,8 @@ def init(self):
     self.acknowledgements = mad_meth.cedar_rules()
     self.references = 'Please remember to cite the instrument articles.'
 
-    self.tag = self.kwargs['inst_code']
-    self.inst_id = self.kwargs['kindat']
+    self.inst_code = self.kwargs['inst_code']
+    self.kindat = self.kwargs['kindat']
 
     return
 
@@ -162,10 +161,11 @@ def clean(self):
 # Use the default Madrigal and pysat methods
 
 # Set the list_remote_files routine
-list_remote_files = functools.partial(mad_meth.list_remote_files,
-                                      inst_code=self.kwargs['inst_code'],
-                                      kindats=self.kwargs['kindat'],
-                                      supported_tags=remote_tags)
+# Need to fix this
+# list_remote_files = functools.partial(mad_meth.list_remote_files,
+#                                       inst_code=self.kwargs['inst_code'],
+#                                       kindats=self.kwargs['kindat'],
+#                                       supported_tags=remote_tags)
 
 # Set the load routine
 load = mad_meth.load
@@ -175,6 +175,7 @@ list_files = functools.partial(ps_gen.list_files,
                                supported_tags=supported_tags)
 
 # Set up the download routine
-download = functools.partial(mad_meth.download,
-                             inst_code=str(self.kwargs['inst_code']),
-                             kindat=self.kwargs['kindat'])
+# Needs to be fixed
+# download = functools.partial(mad_meth.download,
+#                             inst_code=str(self.kwargs['inst_code']),
+#                             kindat=self.kwargs['kindat'])


### PR DESCRIPTION
This addresses #5 and also improves the style of the general instrument template, which will eventually be fixed up to address #1.

To test:
```
import datetime as dt
import pysat
import pysatMadrigal as py_mad

dmsp_f13 = pysat.Instrument(inst_module=py_mad.instruments.dmsp_ivm, tag='utd', inst_id='f13')
out = dmsp_f13._list_remote_files_rtn(dmsp_f13.tag, dmsp_f13.inst_id, user="Your Name", password="your@email", start=py_mad.instruments.dmsp_ivm._test_dates[dmsp_f13.inst_id][dmsp_f13.tag], stop=py_mad.instruments.dmsp_ivm._test_dates[dmsp_f13.inst_id][dmsp_f13.tag] + dt.timedelta(days=1))
print(out)
```

Yields

```
1997-12-31    dms_ut_19971231_13.002.hdf5
1998-01-01    dms_ut_19980101_13.002.hdf5
1998-01-02    dms_ut_19980102_13.002.hdf5
dtype: object
```
