### PR TITLE
Updated .travis.yml for pysat 3.0.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - pip install -r pip_requirements.txt
   # Custom pysat install, no longer needed after 3.0 release
   - cd ..
-  - git clone --single-branch --branch develop-3 https://github.com/pysat/pysat.git
+  - git clone --single-branch --branch v3-0-rc1 https://github.com/pysat/pysat.git
   - cd pysat
   # Install the pysat requirements
   - while read requirement; do conda install --yes $requirement; done < requirements.txt


### PR DESCRIPTION
Update pysat clone to check out the RC branch.  This branch may be modified after https://github.com/pysat/pysat/pull/676 is merged to install pysat from pip.