### PR TITLE
JRO variable name update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   - Fixed remote listing routine to return filenames instead of experiments
   - Fixed bug introduced by change in xarray requiring engine kwarg
   - Fixed bug that would not list multiple types of files
+  - Updated JRO ISR drift variable names
 
 ## [0.0.3] - 2020-06-15
 - pypi compatibility

--- a/pysatMadrigal/instruments/jro_isr.py
+++ b/pysatMadrigal/instruments/jro_isr.py
@@ -238,10 +238,12 @@ def load(fnames, tag=None, inst_id=None):
     """
     # Define the xarray coordinate dimensions (apart from time)
     xcoords = {'drifts': {('time', 'gdalt', 'gdlatr', 'gdlonr', 'kindat',
-                           'kinst'): ['nwlos', 'range', 'vipn2', 'dvipn2',
+                           'kinst'): ['nwlos', 'range', 'vipn', 'dvipn', 'vipe',
+                                      'dvipe', 'vipn2', 'dvipn2',
                                       'vipe1', 'dvipe1', 'vi72', 'dvi72',
-                                      'vi82', 'dvi82', 'paiwl', 'pacwl',
-                                      'pbiwl', 'pbcwl', 'pciel', 'pccel',
+                                      'vi82', 'dvi82', 'vi7', 'dvi7', 'vi8',
+                                      'dvi8', 'paiwl', 'pacwl', 'pbiwl',
+                                      'pbcwl', 'pciel', 'pccel',
                                       'pdiel', 'pdcel', 'jro10', 'jro11'],
                           ('time', ): ['year', 'month', 'day', 'hour', 'min',
                                        'sec', 'spcst', 'pl', 'cbadn', 'inttms',

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -245,14 +245,14 @@ def load(fnames, tag=None, inst_id=None, xarray_coords=None):
 
                         if len(good_ind) == 0:
                             raise ValueError(''.join([
-                                'all data variables {:} are unknown'.format(
+                                'All data variables {:} are unknown.'.format(
                                     xarray_coords[xcoords])]))
                         elif len(good_ind) < len(xarray_coords[xcoords]):
-                            # Remove the coordinates that aren't present
+                            # Remove the coordinates that aren't present.
                             temp = np.array(xarray_coords[xcoords])[good_ind]
 
                             # Warn user, some of this may be due to a file
-                            # format update or change
+                            # format update or change.
                             bad_ind = [i for i in
                                        range(len(xarray_coords[xcoords]))
                                        if i not in good_ind]
@@ -261,7 +261,7 @@ def load(fnames, tag=None, inst_id=None, xarray_coords=None):
                                     np.array(xarray_coords[xcoords])[bad_ind]),
                                 'using only: {:}'.format(temp)]))
 
-                            # Assign good data as a list
+                            # Assign good data as a list.
                             xarray_coords[xcoords] = list(temp)
 
                     # Select the desired data values

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -239,9 +239,9 @@ def load(fnames, tag=None, inst_id=None, xarray_coords=None):
                                                       ldata.columns)]))
                     if not np.all([xkey.lower() in ldata.columns
                                    for xkey in xarray_coords[xcoords]]):
-                        good_ind = [i for i, xkey in enumerate(
-                            xarray_coords[xcoords])
-                                    if xkey.lower() in ldata.columns]
+                        good_ind = [
+                            i for i, xkey in enumerate(xarray_coords[xcoords])
+                            if xkey.lower() in ldata.columns]
 
                         if len(good_ind) == 0:
                             raise ValueError(''.join([

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -239,21 +239,29 @@ def load(fnames, tag=None, inst_id=None, xarray_coords=None):
                                                       ldata.columns)]))
                     if not np.all([xkey.lower() in ldata.columns
                                    for xkey in xarray_coords[xcoords]]):
-                        data_mask = [xkey.lower() in ldata.columns
-                                     for xkey in xarray_coords[xcoords]]
-                        if np.all(~np.array(data_mask)):
-                            raise ValueError(''.join([
-                                'all provided data variables [',
-                                '{:}] are unk'.format(xarray_coords[xcoords]),
-                                'nown, use only: {:}'.format(ldata.columns)]))
-                        else:
-                            logger.warning(''.join([
-                                'unknown data variable in [',
-                                '{:}], use'.format(xarray_coords[xcoords]),
-                                ' only: {:}'.format(ldata.columns)]))
+                        good_ind = [i for i, xkey in enumerate(
+                            xarray_coords[xcoords])
+                                    if xkey.lower() in ldata.columns]
 
+                        if len(good_ind) == 0:
+                            raise ValueError(''.join([
+                                'all data variables {:} are unknown'.format(
+                                    xarray_coords[xcoords])]))
+                        elif len(good_ind) < len(xarray_coords[xcoords]):
                             # Remove the coordinates that aren't present
-                            temp = np.array(xarray_coords[xcoords])[data_mask]
+                            temp = np.array(xarray_coords[xcoords])[good_ind]
+
+                            # Warn user, some of this may be due to a file
+                            # format update or change
+                            bad_ind = [i for i in
+                                       range(len(xarray_coords[xcoords]))
+                                       if i not in good_ind]
+                            logger.warning(''.join([
+                                'unknown data variable(s) {:}, '.format(
+                                    np.array(xarray_coords[xcoords])[bad_ind]),
+                                'using only: {:}'.format(temp)]))
+
+                            # Assign good data as a list
                             xarray_coords[xcoords] = list(temp)
 
                     # Select the desired data values


### PR DESCRIPTION
# Description

Fixed a bug found in which newer JRO drift files have different variable names than earlier files.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import datetime as dt
import pysat
import pysatMadrigal

stime = dt.datetime(2020, 1, 13)
etime = dt.datetime(2020, 1, 23)
jro = pysat.Instruments(inst_module=pysatMadrigal.instruments.jro_isr, tag='drifts')
jro.download(start=stime, stop=etime)
jro.load(date=stime, end_date=etime)

pysat WARNING: unknown data variable(s) ['vipn2' 'dvipn2' 'vipe1' 'dvipe1' 'vi72' 'dvi72' 'vi82' 'dvi82'], using only: ['nwlos' 'range' 'vipn' 'dvipn' 'vipe' 'dvipe' 'vi7' 'dvi7' 'vi8' 'dvi8'
 'paiwl' 'pacwl' 'pbiwl' 'pbcwl' 'pciel' 'pccel' 'pdiel' 'pdcel' 'jro10'
 'jro11']
```

## Test Configuration
* Operating system: OS X Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
