### PR TITLE
Added missing unit tests for `pysatMadrigal.instruments.methods.general`

### DIFF
--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -563,7 +563,7 @@ def good_exp(exp, date_array=None):
     ----------
     exp : MadrigalExperimentFile
         MadrigalExperimentFile object
-    date_array : array-like or NoneType
+    date_array : list-like or NoneType
         List of datetimes to download data for. The sequence of dates need not
         be contiguous. If None, then any valid experiment will be assumed
         to be valid. (default=None)
@@ -768,9 +768,7 @@ def list_files(tag, inst_id, data_path=None, format_str=None,
             two_digit_year_break=two_digit_year_break, delimiter=delimiter))
 
     # Combine the file lists, ensuring the files are correctly ordered
-    if len(out_series) == 0:
-        out = pds.Series(dtype=str)
-    elif len(out_series) == 1:
+    if len(out_series) == 1:
         out = out_series[0]
     else:
         out = pds.concat(out_series).sort_index()

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -35,7 +35,7 @@ def cedar_rules():
 
 
 def load(fnames, tag='', inst_id='', xarray_coords=None):
-    """Loads data from Madrigal into Pandas or XArray
+    """Loads data from Madrigal into Pandas or XArray.
 
     Parameters
     ----------
@@ -43,13 +43,12 @@ def load(fnames, tag='', inst_id='', xarray_coords=None):
         Iterable of filename strings, full path, to data files to be loaded.
         This input is nominally provided by pysat itself.
     tag : str
-        Tag name used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself. While
-        tag defaults to None here, pysat provides '' as the default
-        tag unless specified by user at Instrument instantiation. (default='')
+        Tag name used to identify particular data set to be loaded. This input
+        is nominally provided by pysat itself and is not used here. (default='')
     inst_id : str
-        Satellite ID used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself. (default='')
+        Instrument ID used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself, and is not used here.
+        (default='')
     xarray_coords : list or NoneType
         List of keywords to use as coordinates if xarray output is desired
         instead of a Pandas DataFrame.  Can build an xarray Dataset
@@ -109,7 +108,8 @@ def load(fnames, tag='', inst_id='', xarray_coords=None):
 
     if len(load_file_types["netCDF4"]) > 0:
         # Currently not saving file header data, as all metadata is at
-        # the data variable level
+        # the data variable level. The attributes are only saved if they occur
+        # in all of the loaded files.
         if 'catalog_text' in file_data.attrs:
             notes = file_data.attrs['catalog_text']
         else:

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -34,16 +34,16 @@ def cedar_rules():
     return ackn
 
 
-def load(fnames, tag=None, inst_id=None, xarray_coords=None):
+def load(fnames, tag='', inst_id='', xarray_coords=None):
     """Loads data from Madrigal into Pandas or XArray
 
     Parameters
     ----------
     fnames : array-like
-        iterable of filename strings, full path, to data files to be loaded.
+        Iterable of filename strings, full path, to data files to be loaded.
         This input is nominally provided by pysat itself.
     tag : str
-        tag name used to identify particular data set to be loaded.
+        Tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself. While
         tag defaults to None here, pysat provides '' as the default
         tag unless specified by user at Instrument instantiation. (default='')
@@ -450,31 +450,30 @@ def download(date_array, inst_code=None, kindat=None, data_path=None,
     return
 
 
-def get_remote_filenames(inst_code=None, kindat=None, user=None,
-                         password=None, web_data=None,
-                         url="http://cedar.openmadrigal.org",
+def get_remote_filenames(inst_code=None, kindat=None, user=None, password=None,
+                         web_data=None, url="http://cedar.openmadrigal.org",
                          start=dt.datetime(1900, 1, 1), stop=dt.datetime.now(),
                          date_array=None):
     """Retrieve the remote filenames for a specified Madrigal experiment
 
     Parameters
     ----------
-    inst_code : str
+    inst_code : str or NoneType
         Madrigal instrument code(s), cast as a string.  If multiple are used,
         separate them with commas. (default=None)
-    kindat : str
+    kindat : str or NoneType
         Madrigal experiment code(s), cast as a string.  If multiple are used,
         separate them with commas.  If not supplied, all will be returned.
         (default=None)
-    data_path : str
+    data_path : str or NoneType
         Path to directory to download data to. (default=None)
-    user : str
+    user : str or NoneType
         User string input used for download. Provided by user and passed via
         pysat. If an account is required for dowloads this routine here must
         error if user not supplied. (default=None)
-    password : str
+    password : str or NoneType
         Password for data download. (default=None)
-    web_data : MadrigalData
+    web_data : MadrigalData or NoneType
         Open connection to Madrigal database or None (will initiate using url)
         (default=None)
     url : str
@@ -483,7 +482,7 @@ def get_remote_filenames(inst_code=None, kindat=None, user=None,
         Starting time for file list (defaults to 01-01-1900)
     stop : dt.datetime
         Ending time for the file list (defaults to time of run)
-    date_array : dt.datetime
+    date_array : dt.datetime or NoneType
         Array of datetimes to download data for. The sequence of dates need not
         be contiguous and will be used instead of start and stop if supplied.
         (default=None)
@@ -564,9 +563,10 @@ def good_exp(exp, date_array=None):
     ----------
     exp : MadrigalExperimentFile
         MadrigalExperimentFile object
-    date_array : array-like
-        list of datetimes to download data for. The sequence of dates need not
-        be contiguous.
+    date_array : array-like or NoneType
+        List of datetimes to download data for. The sequence of dates need not
+        be contiguous. If None, then any valid experiment will be assumed
+        to be valid. (default=None)
 
     Returns
     -------
@@ -603,13 +603,13 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
 
     Parameters
     ----------
-    tag : str or NoneType
-        Denotes type of file to load.  Accepted types are <tag strings>.
-        (default=None)
-    inst_id : str or NoneType
-        Specifies the satellite ID for a constellation.  Not used.
-        (default=None)
-    inst_code : str
+    tag : str
+        Denotes type of file to load.  Accepts strings corresponding to the
+        appropriate Madrigal Instrument `tags`.
+    inst_id : str
+        Specifies the instrument ID to load. Accepts strings corresponding to
+        the appropriate Madrigal Instrument `inst_ids`.
+    inst_code : str or NoneType
         Madrigal instrument code(s), cast as a string.  If multiple are used,
         separate them with commas. (default=None)
     kindats : dict
@@ -617,13 +617,13 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
         keys and tags as second level keys with Madrigal experiment code(s)
         as values.  These should be strings, with multiple codes separated by
         commas. (default=None)
-    data_path : str
+    data_path : str or NoneType
         Path to directory to download data to. (default=None)
-    user : str
+    user : str or NoneType
         User string input used for download. Provided by user and passed via
         pysat. If an account is required for dowloads this routine here must
         error if user not supplied. (default=None)
-    password : str
+    password : str or NoneType
         Password for data download. (default=None)
     supported_tags : dict or NoneType
         keys are inst_id, each containing a dict keyed by tag
@@ -704,19 +704,19 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
                                                       two_digit_year_break)
 
 
-def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
+def list_files(tag, inst_id, data_path=None, format_str=None,
                supported_tags=None, file_cadence=dt.timedelta(days=1),
                two_digit_year_break=None, delimiter=None, file_type=None):
     """Return a Pandas Series of every file for chosen Instrument data.
 
     Parameters
     ----------
-    tag : str or NoneType
-        Denotes type of file to load.  Accepted types are <tag strings>.
-        (default=None)
-    inst_id : str or NoneType
-        Specifies the satellite ID for a constellation.  Not used.
-        (default=None)
+    tag : str
+        Denotes type of file to load.  Accepts strings corresponding to the
+        appropriate Madrigal Instrument `tags`.
+    inst_id : str
+        Specifies the instrument ID to load. Accepts strings corresponding to
+        the appropriate Madrigal Instrument `inst_ids`.
     data_path : str or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
@@ -724,7 +724,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
         User specified file format.  If None is specified, the default
         formats associated with the supplied tags are used. (default=None)
     supported_tags : dict or NoneType
-        keys are inst_id, each containing a dict keyed by tag
+        Keys are inst_id, each containing a dict keyed by tag
         where the values file format template strings. (default=None)
     file_cadence : dt.timedelta or pds.DateOffset
         pysat assumes a daily file cadence, but some instrument data file
@@ -838,13 +838,13 @@ def _check_madrigal_params(inst_code, user, password):
 
     Parameters
     ----------
-    inst_code : str
+    inst_code : str or NoneType
         Madrigal instrument code(s), cast as a string.  If multiple are used,
         separate them with commas.
-    user : str
+    user : str or NoneType
         The user's names should be provided in field user. Ruby Payne-Scott
         should be entered as Ruby+Payne-Scott
-    password : str
+    password : str or NoneType
         The password field should be the user's email address. These parameters
             are passed to Madrigal when downloading.
 

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -333,7 +333,7 @@ class TestSimpleFiles(object):
         # Get the data and metadata
         self.data, self.meta = general.load([self.temp_file],
                                             xarray_coords=xarray_coords)
-
+self.eval_data_and_metadata()
         return
 
     def test_load_duplicate_times(self, caplog):

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -256,8 +256,8 @@ class TestSimpleFiles(object):
         return
 
 
-class TestMultFileTypes(object):
-    """Tests for general methods with mixed file types."""
+class TestListFiles(object):
+    """Tests for general methods function `list_files`."""
 
     def setup(self):
         """Create a clean testing setup."""
@@ -317,7 +317,6 @@ class TestMultFileTypes(object):
         same_time : bool
             Use the same base filename for the temporary files with different
             extension if True, use different base filenames if False.
-            (default=False)
 
         """
 
@@ -337,4 +336,52 @@ class TestMultFileTypes(object):
         # Test the listed file names and time indexes
         pysat.utils.testing.assert_lists_equal(out_list, self.temp_files)
         assert len(out_files.index.unique()) == ntimes
+        return
+
+    @pytest.mark.parametrize("same_time", [True, False])
+    @pytest.mark.parametrize("file_type", [
+        ftype for ftype in general.file_types.keys()])
+    def test_list_files_single_type(self, same_time, file_type):
+        """Test `list_files` with multiple file types.
+
+        Parameters
+        ----------
+        same_time : bool
+            Use the same base filename for the temporary files with different
+            extension if True, use different base filenames if False.
+        file_type : str
+            File type to list.
+
+        """
+
+        #  Write the temporary files
+        self.write_temp_files(same_time=same_time)
+
+        # List the temporary files
+        out_files = general.list_files(self.inst.tag, self.inst.inst_id,
+                                       data_path=self.inst.files.data_path,
+                                       supported_tags=self.supported_tags,
+                                       file_type=file_type)
+
+        # Prepare the testing data
+        out_list = [os.path.join(self.inst.files.data_path, ofile)
+                    for ofile in out_files]
+
+        # Test the listed file names and time indexes
+        pysat.utils.testing.assert_list_contains(out_list, self.temp_files,
+                                                 test_case=True)
+        assert len(out_files.index) == 1
+        return
+
+    def test_list_no_files(self):
+        """Test listing files without creating temporary files."""
+
+        # List the temporary files with
+        out_files = general.list_files(self.inst.tag, self.inst.inst_id,
+                                       data_path=self.inst.files.data_path,
+                                       supported_tags=self.supported_tags)
+
+        # Test the output
+        assert len(out_files) == 0
+        assert len(out_files.index) == 0
         return

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -620,8 +620,7 @@ class TestListFiles(object):
                     for ofile in out_files]
 
         # Test the listed file names and time indexes
-        pysat.utils.testing.assert_list_contains(out_list, self.temp_files,
-                                                 test_case=True)
+        pysat.utils.testing.assert_list_contains(out_list, self.temp_files)
         assert len(out_files.index) == 1
         return
 

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -645,8 +645,8 @@ class TestListFiles(object):
         return
 
 
-class TestMadrigalWrapper(object):
-    """Unit tests for the MadrigalWeb related general functions."""
+class TestMadrigalExp(object):
+    """Unit tests for the MadrigalWeb functions that use MadrigalExperiment."""
 
     def setup(self):
         """Create a clean testing environment."""

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -333,7 +333,8 @@ class TestSimpleFiles(object):
         # Get the data and metadata
         self.data, self.meta = general.load([self.temp_file],
                                             xarray_coords=xarray_coords)
-self.eval_data_and_metadata()
+
+        self.eval_data_and_metadata()
         return
 
     def test_load_duplicate_times(self, caplog):

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -275,9 +275,10 @@ class TestListFiles(object):
     def teardown(self):
         """Clean up previous testing."""
 
-        # Remove the temporary directory and file
+        # Remove the temporary file, if it exists
         for tfile in self.temp_files:
-            os.remove(tfile)
+            if os.path.isfile(tfile):
+                os.remove(tfile)
 
         del self.inst, self.temp_files, self.supported_tags
         return

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -61,8 +61,8 @@ class TestLocal(object):
         assert self.out[1] == pysat.Meta()
         return
 
-    @pytest.mark.skipif(pv_major < 3 or (pv_major == 3 and pv_minor < 1)
-                        or (pv_major == 3 and pv_minor == 0 and pv_bug > 1),
+    @pytest.mark.skipif(pv_major < 3 or (pv_major == 3 and pv_minor == 0
+                                         and pv_bug <= 1),
                         reason="requires newer pysat version.")
     @pytest.mark.parametrize("pad", [None, pds.DateOffset(days=2)])
     def test_filter_data_single_date(self, pad):

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -329,9 +329,12 @@ class TestMultFileTypes(object):
                                        data_path=self.inst.files.data_path,
                                        supported_tags=self.supported_tags)
 
-        # Test the output
+        # Prepare the testing data
         out_list = [os.path.join(self.inst.files.data_path, ofile)
                     for ofile in out_files]
+        ntimes = 1 if same_time else len(self.temp_files)
 
+        # Test the listed file names and time indexes
         pysat.utils.testing.assert_lists_equal(out_list, self.temp_files)
+        assert len(out_files.index.unique()) == ntimes
         return

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -21,6 +21,10 @@ import xarray as xr
 
 from pysatMadrigal.instruments.methods import general
 
+# Get the pysat version for skipping tests that currently require the
+# develop branch
+pv_major, pv_minor, pv_bug = [int(ps) for ps in pysat.__version__.split(".")]
+
 
 class TestLocal(object):
     """Unit tests for general methods that run locally."""
@@ -57,8 +61,8 @@ class TestLocal(object):
         assert self.out[1] == pysat.Meta()
         return
 
-    @pytest.mark.skipif(not hasattr(pysat.instruments.pysat_testing,
-                                    '_test_dates'),
+    @pytest.mark.skipif(pv_major < 3 or (pv_major == 3 and pv_minor < 1)
+                        or (pv_major == 3 and pv_minor == 0 and pv_bug > 1),
                         reason="requires newer pysat version.")
     @pytest.mark.parametrize("pad", [None, pds.DateOffset(days=2)])
     def test_filter_data_single_date(self, pad):


### PR DESCRIPTION
# Description

Partially addresses #3 by adding unit tests for the functions in the general methods sub-module.

# Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality or documentation)

# How Has This Been Tested?

Ran new unit tests locally

## Test Configuration
* Operating system: OS X Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant: develop branch of pysat

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
