### PR TITLE
Updated cleaning methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.1.0] - 2021-XX-XX
 - Enhancements
    - Improved definitions of general and GNSS meta data
+   - Removed unused logic in cleaning routines
+   - Moved warning for no cleaning of JRO ISR data to preprocess
 - Documentation
    - Added examples for JRO and GNSS data
 - Testing

--- a/pysatMadrigal/instruments/dmsp_ivm.py
+++ b/pysatMadrigal/instruments/dmsp_ivm.py
@@ -129,7 +129,7 @@ def init(self):
 
 
 def clean(self):
-    """Routine to return DMSP IVM data cleaned to the specified level
+    """Clean DMSP IVM data cleaned to the specified level.
 
     Note
     ----
@@ -138,31 +138,28 @@ def clean(self):
     'clean' enforces that both RPA and DM flags are <= 1
     'dusty' <= 2
     'dirty' <= 3
-    'none' Causes pysat to skip this routine
 
-    Routine is called by pysat, and not by the end user directly.
+    When called directly by pysat, a clean level of 'none' causes pysat to skip
+    this routine.
 
     """
 
     if self.tag == 'utd':
         if self.clean_level == 'clean':
-            idx, = np.where((self['rpa_flag_ut'] <= 1)
-                            & (self['idm_flag_ut'] <= 1))
+            iclean, = np.where((self['rpa_flag_ut'] <= 1)
+                               & (self['idm_flag_ut'] <= 1))
         elif self.clean_level == 'dusty':
-            idx, = np.where((self['rpa_flag_ut'] <= 2)
-                            & (self['idm_flag_ut'] <= 2))
+            iclean, = np.where((self['rpa_flag_ut'] <= 2)
+                               & (self['idm_flag_ut'] <= 2))
         elif self.clean_level == 'dirty':
-            idx, = np.where((self['rpa_flag_ut'] <= 3)
-                            & (self['idm_flag_ut'] <= 3))
-        else:
-            idx = slice(0, self.index.shape[0])
+            iclean, = np.where((self['rpa_flag_ut'] <= 3)
+                               & (self['idm_flag_ut'] <= 3))
     else:
-        if self.clean_level in ['clean', 'dusty', 'dirty']:
-            logger.warning('this level 1 data has no quality flags')
-        idx = slice(0, self.index.shape[0])
+        logger.warning('this level 1 data has no quality flags')
+        iclean = slice(0, self.index.shape[0])
 
     # Downselect data based upon cleaning conditions above
-    self.data = self[idx]
+    self.data = self[iclean]
 
     return
 

--- a/pysatMadrigal/instruments/gnss_tec.py
+++ b/pysatMadrigal/instruments/gnss_tec.py
@@ -94,12 +94,12 @@ def init(self):
 
 
 def clean(self):
-    """Routine to return GNSS TEC data at a specific level
+    """Clean GNSS TEC data to a specific level.
 
     Note
     ----
-    Supports 'clean', 'dusty', 'dirty', or 'None'.
-    Routine is called by pysat, and not by the end user directly.
+    Supports 'clean', 'dusty', and 'dirty'.  Not called by pysat if
+    `clean_level` is None.
 
     """
     if self.tag == "vtec":

--- a/pysatMadrigal/instruments/jro_isr.py
+++ b/pysatMadrigal/instruments/jro_isr.py
@@ -82,17 +82,9 @@ _test_dates = {'': {'drifts': dt.datetime(2010, 1, 19),
                     'oblique_rand': dt.datetime(2000, 11, 9),
                     'oblique_long': dt.datetime(2010, 4, 12)}}
 
+
 # ----------------------------------------------------------------------------
 # Instrument methods
-
-# Madrigal will sometimes include multiple days within a file
-# labeled with a single date.
-# Filter out this extra data using the pysat nanokernel processing queue.
-# To ensure this function is always applied first, we set the filter
-# function as the default function for (JRO).
-# Default function is run first by the nanokernel on every load call.
-preprocess = general.filter_data_single_date
-
 
 def init(self):
     """Initializes the Instrument object with values specific to JRO ISR
@@ -108,7 +100,7 @@ def init(self):
 
 
 def clean(self):
-    """Routine to return JRO ISR data cleaned to the specified level
+    """Clean the JRO ISR data cleaned to the specified level.
 
     Note
     ----
@@ -116,14 +108,13 @@ def clean(self):
     'clean' is unknown for oblique modes, over 200 km for drifts
     'dusty' is the same as clean
     'Dirty' is the same as clean
-    'None' None
 
-    Routine is called by pysat, and not by the end user directly.
+    When called by pysat, a clean level of None will skip this routine.
 
     """
 
     # Default to selecting all of the data
-    idx = {'gdalt': [i for i in range(self.data.indexes['gdalt'].shape[0])]}
+    iclean = {'gdalt': [i for i in range(self.data.indexes['gdalt'].shape[0])]}
 
     if self.tag.find('oblique') == 0:
         # Oblique profile cleaning
@@ -142,16 +133,28 @@ def clean(self):
             if self.clean_level in ['clean', 'dusty']:
                 logger.warning('this level 2 data has no quality flags')
 
-            ida, = np.where((self.data.indexes['gdalt'] > 200.0))
-            idx['gdalt'] = np.unique(ida)
-        else:
-            logger.warning(' '.join(["interpretation of drifts below 200 km",
-                                     "should always be done in partnership",
-                                     "with the contact people"]))
+            idalt, = np.where((self.data.indexes['gdalt'] > 200.0))
+            iclean['gdalt'] = np.unique(idalt)
 
-    # downselect data based upon cleaning conditions above
-    self.data = self[idx]
+    # Downselect data based upon cleaning conditions above
+    self.data = self[iclean]
 
+    return
+
+
+def preprocess(self):
+    """Preprocess data to default loaded data to a single day."""
+
+    # Madrigal will sometimes include multiple days within a file
+    # labeled with a single date. This routine filters out this extra data
+    # using the pysat nanokernel processing queue.
+    general.filter_data_single_date(self)
+
+    # Warn the user about low altitude drifts if no cleaning is being performed
+    if self.clean_level is None:
+        logger.warning(' '.join(["interpretation of drifts below 200 km",
+                                 "should always be done in partnership",
+                                 "with the contact people"]))
     return
 
 

--- a/pysatMadrigal/instruments/jro_isr.py
+++ b/pysatMadrigal/instruments/jro_isr.py
@@ -151,7 +151,7 @@ def preprocess(self):
     general.filter_data_single_date(self)
 
     # Warn the user about low altitude drifts if no cleaning is being performed
-    if self.clean_level is None:
+    if self.clean_level == 'none' or self.clean_level is None:
         logger.warning(' '.join(["interpretation of drifts below 200 km",
                                  "should always be done in partnership",
                                  "with the contact people"]))


### PR DESCRIPTION
# Description

When looking at coveralls, I discovered that the clean routines contained logic for 'none'.  Since clean is not called with this input, I decided to remove it.  I also:
- moved a no-cleaning warning in JRO ISR to preprocess so that it will be accessible
- Updated the clean docstrings

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
import pysatMadrigal as py_mad

jro = pysat.Instrument(inst_module=py_mad.instruments.jro_isr, tag='drifts', clean_level='none')
jro.load(2014, 20)

pysat WARNING: unknown data variable(s) ['vipn' 'dvipn' 'vipe' 'dvipe' 'vi7' 'dvi7' 'vi8' 'dvi8'], using only: ['nwlos' 'range' 'vipn2' 'dvipn2' 'vipe1' 'dvipe1' 'vi72' 'dvi72' 'vi82'
 'dvi82' 'paiwl' 'pacwl' 'pbiwl' 'pbcwl' 'pciel' 'pccel' 'pdiel' 'pdcel'
 'jro10' 'jro11']
WARNING:pysat:unknown data variable(s) ['vipn' 'dvipn' 'vipe' 'dvipe' 'vi7' 'dvi7' 'vi8' 'dvi8'], using only: ['nwlos' 'range' 'vipn2' 'dvipn2' 'vipe1' 'dvipe1' 'vi72' 'dvi72' 'vi82'
 'dvi82' 'paiwl' 'pacwl' 'pbiwl' 'pbcwl' 'pciel' 'pccel' 'pdiel' 'pdcel'
 'jro10' 'jro11']
<ipython-input-10-027e4e553f7c>:1: UserWarning: Metadata set to defaults, as they were missing in the Instrument
  jro.load(2014, 20)
pysat WARNING: interpretation of drifts below 200 km should always be done in partnership with the contact people
WARNING:pysat:interpretation of drifts below 200 km should always be done in partnership with the contact people
```

## Test Configuration
* Operating system: OS X Mojave
* Version number: Python 3.8
* Any details about your local setup that are relevant: develop branch of pysat

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
