### PR TITLE
Meta load netcdf bug

### DIFF
--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -120,14 +120,18 @@ def load(fnames, tag='', inst_id='', xarray_coords=None):
         meta_items.extend([dkey for dkey in file_data.coords.keys()])
 
         for item in meta_items:
-            name_string = item
-            unit_string = file_data[item].attrs['units']
-            desc_string = file_data[item].attrs['description']
-            meta[name_string.lower()] = {meta.labels.name: name_string,
-                                         meta.labels.notes: notes,
-                                         meta.labels.units: unit_string,
-                                         meta.labels.desc: desc_string,
-                                         meta.labels.fill_val: np.nan}
+            # Set the meta values for the expected labels
+            meta_dict = {meta.labels.name: item, meta.labels.fill_val: np.nan,
+                         meta.labels.notes: notes}
+
+            for key, label in [('units', meta.labels.units),
+                               ('description', meta.labels.desc)]:
+                if key in file_data[item].attrs.keys():
+                    meta_dict[label] = file_data[item].attrs[key]
+                else:
+                    meta_dict[label] = ''
+
+            meta[item.lower()] = meta_dict
 
             # Remove any metadata from xarray
             file_data[item].attrs = {}

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -115,7 +115,11 @@ def load(fnames, tag='', inst_id='', xarray_coords=None):
         else:
             notes = "No catalog text"
 
-        for item in file_data.data_vars.keys():
+        # Get the coordinate and data variable names
+        meta_items = [dkey for dkey in file_data.data_vars.keys()]
+        meta_items.extend([dkey for dkey in file_data.coords.keys()])
+
+        for item in meta_items:
             name_string = item
             unit_string = file_data[item].attrs['units']
             desc_string = file_data[item].attrs['description']

--- a/pysatMadrigal/tests/test_instruments.py
+++ b/pysatMadrigal/tests/test_instruments.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+# Full license can be found in License.md
+# Full author list can be found in .zenodo.json file
+# DOI:10.5281/zenodo.3824979
+# ----------------------------------------------------------------------------
+"""Unit tests for the Instruments."""
+
 import tempfile
 import pytest
 
@@ -50,22 +57,20 @@ for method in method_list:
 
 class TestInstruments(InstTestClass):
     def setup_class(self):
-        """Runs once before the tests to initialize the testing setup
-        """
+        """Initialize the testing setup."""
         # Make sure to use a temporary directory so that the user's setup is
         # not altered
         self.tempdir = tempfile.TemporaryDirectory()
         self.saved_path = pysat.params['data_dirs']
         pysat.params.data['data_dirs'] = [self.tempdir.name]
 
-        # Developers for instrument libraries should update the following line
-        # to point to their own subpackage location, e.g.,
-        # self.inst_loc = mypackage.instruments
+        # Point to the Instrument subpackage location
         self.inst_loc = pysatMadrigal.instruments
+        return
 
     def teardown_class(self):
-        """Runs after every method to clean up previous testing
-        """
+        """Clean up previous testing."""
         pysat.params.data['data_dirs'] = self.saved_path
         self.tempdir.cleanup()
         del self.inst_loc, self.saved_path, self.tempdir
+        return

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -436,8 +436,9 @@ class TestNetCDFFiles(object):
                                                                size=(10, 10))
 
                 # Write the default Madrigal meta data
-                dat_dict['value'].units = 'test'
-                dat_dict['value'].description = 'test data set'
+                for dat_name in ['lat', 'lon', 'value']:
+                    dat_dict[dat_name].units = 'deg'
+                    dat_dict[dat_name].description = 'test data set'
 
             self.temp_files.append(tfile)
 
@@ -446,11 +447,27 @@ class TestNetCDFFiles(object):
     def eval_dataset_meta_output(self):
         """Evaluate the dataset and meta output for the temp files."""
 
+        # Evaluate the Instrument data variables and coordinates
         pysat.utils.testing.assert_lists_equal(
             [ckey for ckey in self.data.coords.keys()], ['time', 'lat', 'lon'])
         assert "value" in self.data.data_vars
         assert self.data['time'].shape[0] == len(self.temp_files)
-        assert "value" in self.meta.keys()
+
+        # Evaluate the meta data
+        meta_keys = ['timestamps', 'lat', 'lon', 'value']
+        pysat.utils.testing.assert_lists_equal(
+            [ckey for ckey in self.meta.keys()], meta_keys)
+
+        for mkey in meta_keys:
+            uval = '' if mkey == 'timestamps' else 'deg'
+            dval = '' if mkey == 'timestamps' else 'test data set'
+            assert self.meta[mkey, self.meta.labels.units] == uval, \
+                "unexpected unit metadata for {:}: {:}".format(
+                    repr(mkey), repr(self.meta[mkey, self.meta.labels.units]))
+            assert self.meta[mkey, self.meta.labels.desc] == dval, \
+                "unexpected unit metadata for {:}: {:}".format(
+                    repr(mkey), repr(self.meta[mkey, self.meta.labels.desc]))
+
         return
 
     @pytest.mark.parametrize("nfiles", [1, 2, 3])


### PR DESCRIPTION
# Description

Found a bug when running data validation that revealed meta data available in the netCDF4 files was not being loaded for the coordinates.

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-8-0f94a05e9ffd> in <module>
----> 1 (pairs, pairs_meta, inst_dat, mod_dat, inst_loc) = sami3_val.pair_sami3_inst(stime, etime, inst_name, mod_prefix,
      2                                     user=user, password=password,
      3                                     skip_download=skip_download,
      4                                     mod_dir=mod_dir, data_dir=data_dir,
      5                                     data_type=data_type, comp_clean=comp_clean)

~/Programs/Models/SAMI3/tools/sami3_validation_rout.py in pair_sami3_inst(stime, etime, inst_name, mod_prefix, user, password, skip_download, mod_dir, data_dir, data_type, comp_clean)
    299                     'exb_mer': 'u1p'}
    300 
--> 301     inst_sami = pm_utils.match.collect_inst_model_pairs(
    302         stime, etime, tinc, inst,
    303         inst_download_kwargs={'skip_download': skip_download},

~/Programs/Git/pysatModels/pysatModels/utils/match.py in collect_inst_model_pairs(start, stop, tinc, inst, inst_download_kwargs, model_load_rout, model_load_kwargs, inst_clean_rout, inst_lon_name, mod_lon_name, lon_pos, inst_name, mod_name, mod_datetime_name, mod_time_name, mod_units, sel_name, time_method, pair_method, method, model_label, comp_clean)
    219 
    220             if not inst.empty and np.any(inst.index >= istart):
--> 221                 added_names = extract.extract_modelled_observations(
    222                     inst=inst, model=mdata, inst_name=inst_name,
    223                     mod_name=mod_name, mod_datetime_name=mod_datetime_name,

~/Programs/Git/pysatModels/pysatModels/utils/extract.py in extract_modelled_observations(inst, model, inst_name, mod_name, mod_datetime_name, mod_time_name, mod_units, sel_name, time_method, pair_method, method, model_label, model_units_attr)
    807         long_units = re.split(r"\W+|_",
    808                               inst.meta[iname, inst.meta.labels.units])[0]
--> 809         inst_scale[i] = pyutils.scale_units(mod_units[i], long_units)
    810 
    811     # Determine the model time resolution

~/Programs/Git/pysat/pysat/utils/_core.py in scale_units(out_unit, in_unit)
    100 
    101     if in_key not in accepted_units.keys():
--> 102         raise ValueError('Unknown input unit {:}'.format(in_unit))
    103 
    104     if out_key in ['m', 'm/s', 'm-3'] or in_key in ['m', 'm/s', 'm-3']:

ValueError: Unknown input unit 
```

The unknown in put unit was a blank string, but the file has the data present:

```
$ ncdump gps130102g.002.netCDF4 | more
netcdf gps130102g.002 {
dimensions:
        timestamps = 288 ;
        gdlat = 180 ;
        glon = 360 ;
variables:
        double timestamps(timestamps) ;
                timestamps:units = "Unix seconds" ;
                timestamps:description = "Number of seconds since UT midnight 1970-01-01" ;
        double gdlat(gdlat) ;
                gdlat:units = "deg" ;
                gdlat:description = "Geodetic latitude of measurement" ;
```

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Rerunning the code that originally raised the error.  Also:

```
import pysat
import pysatMadrigal as py_mad

tec = pysat.Instrument(inst_module=py_mad.instruments.gnss_tec, tag='vtec')
tec.load(2013, 2)

tec.meta['gdlat']
```

The fixed code yields:
```
units                                                      deg
long_name                                                gdlat
notes        Catalog information from record 0:KRECC       ...
desc                          Geodetic latitude of measurement
value_min                                                -90.0
value_max                                                 90.0
fill                                                       NaN
children                                                  None
Name: gdlat, dtype: object
```

## Test Configuration
* Operating system: OS X Mojave
* Version number: Python 3.8
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
