### PR TITLE
Remote list break fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    - Moved warning for no cleaning of JRO ISR data to preprocess
    - Standardized the Instrument method kwarg defaults
    - Added 'site' tag to the GNSS TEC Instrument
+   - Added support for varied use of `two_digit_year_break` to 
+     `methods.general.list_remote_files`
+   - Implemented `two_digit_year_break` support for `vtec` GNSS TEC Instrument
 - Documentation
    - Added examples for JRO and GNSS data
    - Improved the docstring style

--- a/pysatMadrigal/instruments/gnss_tec.py
+++ b/pysatMadrigal/instruments/gnss_tec.py
@@ -299,7 +299,7 @@ def list_remote_files(tag, inst_id, start=dt.datetime(1998, 10, 15),
         provided by pysat itself.
     start : dt.datetime or NoneType
         Starting time for file list. If None, replaced with default.
-        (default=01-01-1900)
+        (default=10-15-1998)
     stop : dt.datetime or NoneType
         Ending time for the file list. If None, replaced with default.
         (default=time of run)

--- a/pysatMadrigal/instruments/gnss_tec.py
+++ b/pysatMadrigal/instruments/gnss_tec.py
@@ -119,7 +119,9 @@ def clean(self):
 list_remote_files = functools.partial(general.list_remote_files,
                                       supported_tags=remote_tags,
                                       inst_code=madrigal_inst_code,
-                                      kindats=madrigal_tag)
+                                      kindats=madrigal_tag,
+                                      two_digit_year_break={'': {'vtec': 99,
+                                                                 'site': None}})
 
 
 def list_files(tag, inst_id, data_path=None, format_str=None,

--- a/pysatMadrigal/instruments/gnss_tec.py
+++ b/pysatMadrigal/instruments/gnss_tec.py
@@ -37,7 +37,6 @@ Please provide name and email when downloading data with this routine.
 """
 
 import datetime as dt
-import functools
 import numpy as np
 
 from pysat import logger

--- a/pysatMadrigal/instruments/gnss_tec.py
+++ b/pysatMadrigal/instruments/gnss_tec.py
@@ -115,14 +115,6 @@ def clean(self):
 #
 # Use the default Madrigal methods
 
-# Support listing files currently available on remote server (Madrigal)
-list_remote_files = functools.partial(general.list_remote_files,
-                                      supported_tags=remote_tags,
-                                      inst_code=madrigal_inst_code,
-                                      kindats=madrigal_tag,
-                                      two_digit_year_break={'': {'vtec': 99,
-                                                                 'site': None}})
-
 
 def list_files(tag, inst_id, data_path=None, format_str=None,
                file_cadence=dt.timedelta(days=1), delimiter=None,
@@ -292,3 +284,55 @@ def load(fnames, tag='', inst_id=''):
                      meta.labels.max_val: min_lon + 360.0}
 
     return data, meta
+
+
+def list_remote_files(tag, inst_id, start=dt.datetime(1900, 1, 1),
+                      stop=dt.datetime.utcnow(), user=None, password=None):
+    """Return a Pandas Series of every file for chosen remote data.
+
+    Parameters
+    ----------
+    tag : str
+        Denotes type of file to load.  This input is nominally provided
+        by pysat itself.
+    inst_id : str
+        Specifies the satellite or instrument ID. This input is nominally
+        provided by pysat itself.
+    start : dt.datetime or NoneType
+        Starting time for file list. If None, replaced with default.
+        (default=01-01-1900)
+    stop : dt.datetime or NoneType
+        Ending time for the file list. If None, replaced with default.
+        (default=time of run)
+    user : str or NoneType
+        Username to be passed along to resource with relevant data.
+        (default=None)
+    password : str or NoneType
+        User password to be passed along to resource with relevant data.
+        (default=None)
+
+    Returns
+    -------
+    files : pds.Series
+        A series of filenames, see `pysat.utils.files.process_parsed_filenames`
+        for more information.
+
+    See Also
+    --------
+    pysatMadrigal.instruments.methods.general.list_remote_files
+
+    """
+
+    if tag == 'site':
+        files = general.list_remote_files(
+            supported_tags=remote_tags, inst_code=madrigal_inst_code,
+            kindats=madrigal_tag, start=start, stop=stop, user=user,
+            password=password)
+
+    elif tag == 'vtec':
+        files = general.list_remote_files(
+            supported_tags=remote_tags, inst_code=madrigal_inst_code,
+            kindats=madrigal_tag, start=start, stop=stop, user=user,
+            password=password, two_digit_year_break=99)
+
+    return files

--- a/pysatMadrigal/instruments/gnss_tec.py
+++ b/pysatMadrigal/instruments/gnss_tec.py
@@ -324,14 +324,14 @@ def list_remote_files(tag, inst_id, start=dt.datetime(1900, 1, 1),
 
     if tag == 'site':
         files = general.list_remote_files(
-            supported_tags=remote_tags, inst_code=madrigal_inst_code,
-            kindats=madrigal_tag, start=start, stop=stop, user=user,
-            password=password)
+            tag, inst_id, supported_tags=remote_tags,
+            inst_code=madrigal_inst_code, kindats=madrigal_tag, start=start,
+            stop=stop, user=user, password=password)
 
     elif tag == 'vtec':
         files = general.list_remote_files(
-            supported_tags=remote_tags, inst_code=madrigal_inst_code,
-            kindats=madrigal_tag, start=start, stop=stop, user=user,
-            password=password, two_digit_year_break=99)
+            tag, inst_id, supported_tags=remote_tags,
+            inst_code=madrigal_inst_code, kindats=madrigal_tag, start=start,
+            stop=stop, user=user, password=password, two_digit_year_break=99)
 
     return files

--- a/pysatMadrigal/instruments/gnss_tec.py
+++ b/pysatMadrigal/instruments/gnss_tec.py
@@ -285,7 +285,7 @@ def load(fnames, tag='', inst_id=''):
     return data, meta
 
 
-def list_remote_files(tag, inst_id, start=dt.datetime(1900, 1, 1),
+def list_remote_files(tag, inst_id, start=dt.datetime(1998, 10, 15),
                       stop=dt.datetime.utcnow(), user=None, password=None):
     """Return a Pandas Series of every file for chosen remote data.
 

--- a/pysatMadrigal/instruments/gnss_tec.py
+++ b/pysatMadrigal/instruments/gnss_tec.py
@@ -323,15 +323,13 @@ def list_remote_files(tag, inst_id, start=dt.datetime(1998, 10, 15),
     """
 
     if tag == 'site':
-        files = general.list_remote_files(
-            tag, inst_id, supported_tags=remote_tags,
-            inst_code=madrigal_inst_code, kindats=madrigal_tag, start=start,
-            stop=stop, user=user, password=password)
-
+        two_break = None
     elif tag == 'vtec':
-        files = general.list_remote_files(
-            tag, inst_id, supported_tags=remote_tags,
-            inst_code=madrigal_inst_code, kindats=madrigal_tag, start=start,
-            stop=stop, user=user, password=password, two_digit_year_break=99)
+        two_break = 99
+
+    files = general.list_remote_files(
+        tag, inst_id, supported_tags=remote_tags,
+        inst_code=madrigal_inst_code, kindats=madrigal_tag, start=start,
+        stop=stop, user=user, password=password, two_digit_year_break=two_break)
 
     return files

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -702,11 +702,12 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
         if inst_id not in two_digit_year_break.keys():
             estr = ''.join(['`two_digit_year_break` does not include key ',
                             'value ', inst_id])
-            raise ValueError(estr)
-            if tag not in two_digit_year_break[inst_id].keys():
-                estr = ''.join(['`two_digit_year_break[inst_id]` does not ',
-                                'include key value ', tag])
-                raise ValueError(estr)
+            raise KeyError(estr)
+
+        if tag not in two_digit_year_break[inst_id].keys():
+            estr = ''.join(['`two_digit_year_break[inst_id]` does not ',
+                            'include key value ', tag])
+            raise KeyError(estr)
 
         # Extract value from input dict
         two_digit_year_break = two_digit_year_break[inst_id][tag]

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -695,7 +695,7 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
     format_str = supported_tags[inst_id][tag]
     kindat = kindats[inst_id][tag]
 
-    # TODO(#1022) Note that default of `pysat.Instrument.remote_file_list`
+    # TODO(#1022, pysat) Note default of `pysat.Instrument.remote_file_list`
     #  for start and stop is None. Setting defaults needed for Madrigal.
     if start is None:
         start = dt.datetime(1900, 1, 1)

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -697,8 +697,8 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
     format_str = supported_tags[inst_id][tag]
     kindat = kindats[inst_id][tag]
 
-    # Note that default of pysat.Instrument.remote_file_list for start and stop
-    # is None. Setting defaults needed for Madrigal.
+    # Note that default of `pysat.Instrument.remote_file_list` for start and
+    # stop is None. Setting defaults needed for Madrigal.
     if start is None:
         start = dt.datetime(1900, 1, 1)
     if stop is None:

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -640,9 +640,9 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
     url : str
         URL for Madrigal site (default='http://cedar.openmadrigal.org')
     two_digit_year_break : int or NoneType
-        If filenames only store two digits for the year, then
-        '1900' will be added for years >= two_digit_year_break
-        and '2000' will be added for years < two_digit_year_break. (default=None)
+        If filenames only store two digits for the year, then '1900' will be
+        added for years >= two_digit_year_break and '2000' will be added for
+        years < two_digit_year_break. (default=None)
     start : dt.datetime
         Starting time for file list.  (default=01-01-1900)
     stop : dt.datetime

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -698,7 +698,7 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
     kindat = kindats[inst_id][tag]
 
     # Note that default of pysat.Instrument.remote_file_list for start and stop
-    # is None.
+    # is None. Setting defaults needed for Madrigal.
     if start is None:
         start = dt.datetime(1900, 1, 1)
     if stop is None:

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -630,7 +630,7 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
         Path to directory to download data to. (default=None)
     user : str or NoneType
         User string input used for download. Provided by user and passed via
-        pysat. If an account is required for dowloads this routine here must
+        pysat. If an account is required for downloads this routine here must
         error if user not supplied. (default=None)
     password : str or NoneType
         Password for data download. (default=None)
@@ -639,16 +639,16 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
         where the values file format template strings. (default=None)
     url : str
         URL for Madrigal site (default='http://cedar.openmadrigal.org')
-    two_digit_year_break : int or dict or NoneType
+    two_digit_year_break : int or NoneType
         If filenames only store two digits for the year, then
         '1900' will be added for years >= two_digit_year_break
         and '2000' will be added for years < two_digit_year_break.
-        If user inputs a dict, must be keyed by `inst_id`, containing a dict
-        keyed by `tag`, containing values for `two_digit_year_break`.
-    start : dt.datetime
-        Starting time for file list (defaults to 01-01-1900)
-    stop : dt.datetime
-        Ending time for the file list (defaults to time of run)
+    start : dt.datetime or NoneType
+        Starting time for file list. If None, replaces with default.
+        (default=01-01-1900)
+    stop : dt.datetime or NoneType
+        Ending time for the file list. If None, replaces with default.
+        (default=time of run)
 
     Returns
     -------
@@ -697,20 +697,12 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
     format_str = supported_tags[inst_id][tag]
     kindat = kindats[inst_id][tag]
 
-    # Pull out two_digit_year_break if user supplies a dict
-    if isinstance(two_digit_year_break, dict):
-        if inst_id not in two_digit_year_break.keys():
-            estr = ''.join(['`two_digit_year_break` does not include key ',
-                            'value ', inst_id])
-            raise KeyError(estr)
-
-        if tag not in two_digit_year_break[inst_id].keys():
-            estr = ''.join(['`two_digit_year_break[inst_id]` does not ',
-                            'include key value ', tag])
-            raise KeyError(estr)
-
-        # Extract value from input dict
-        two_digit_year_break = two_digit_year_break[inst_id][tag]
+    # Note that default of pysat.Instrument.remote_file_list for start and stop
+    # is None.
+    if start is None:
+        start = dt.datetime(1900, 1, 1)
+    if stop is None:
+        stop = dt.datetime.utcnow()
 
     # Retrieve remote file experiment list
     files = get_remote_filenames(inst_code=inst_code, kindat=kindat, user=user,

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -642,13 +642,11 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
     two_digit_year_break : int or NoneType
         If filenames only store two digits for the year, then
         '1900' will be added for years >= two_digit_year_break
-        and '2000' will be added for years < two_digit_year_break.
-    start : dt.datetime or NoneType
-        Starting time for file list. If None, replaces with default.
-        (default=01-01-1900)
-    stop : dt.datetime or NoneType
-        Ending time for the file list. If None, replaces with default.
-        (default=time of run)
+        and '2000' will be added for years < two_digit_year_break. (default=None)
+    start : dt.datetime
+        Starting time for file list.  (default=01-01-1900)
+    stop : dt.datetime
+        Ending time for the file list. (default=time of run)
 
     Returns
     -------

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -639,10 +639,12 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
         where the values file format template strings. (default=None)
     url : str
         URL for Madrigal site (default='http://cedar.openmadrigal.org')
-    two_digit_year_break : int
+    two_digit_year_break : int or dict or NoneType
         If filenames only store two digits for the year, then
         '1900' will be added for years >= two_digit_year_break
         and '2000' will be added for years < two_digit_year_break.
+        If user inputs a dict, must be keyed by `inst_id`, containing a dict
+        keyed by `tag`, containing values for `two_digit_year_break`.
     start : dt.datetime
         Starting time for file list (defaults to 01-01-1900)
     stop : dt.datetime
@@ -694,6 +696,20 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
     # Raise KeyError if input dictionaries don't match the input
     format_str = supported_tags[inst_id][tag]
     kindat = kindats[inst_id][tag]
+
+    # Pull out two_digit_year_break if user supplies a dict
+    if isinstance(two_digit_year_break, dict):
+        if inst_id not in two_digit_year_break.keys():
+            estr = ''.join(['`two_digit_year_break` does not include key ',
+                            'value ', inst_id])
+            raise ValueError(estr)
+            if tag not in two_digit_year_break[inst_id].keys():
+                estr = ''.join(['`two_digit_year_break[inst_id]` does not ',
+                                'include key value ', tag])
+                raise ValueError(estr)
+
+        # Extract value from input dict
+        two_digit_year_break = two_digit_year_break[inst_id][tag]
 
     # Retrieve remote file experiment list
     files = get_remote_filenames(inst_code=inst_code, kindat=kindat, user=user,

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -695,8 +695,8 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
     format_str = supported_tags[inst_id][tag]
     kindat = kindats[inst_id][tag]
 
-    # Note that default of `pysat.Instrument.remote_file_list` for start and
-    # stop is None. Setting defaults needed for Madrigal.
+    # TODO(#1022) Note that default of `pysat.Instrument.remote_file_list`
+    #  for start and stop is None. Setting defaults needed for Madrigal.
     if start is None:
         start = dt.datetime(1900, 1, 1)
     if stop is None:

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -176,7 +176,7 @@ class TestErrors(object):
 
         tdyb = {'': {'not_tag': 99},
                 'not_id': {'tag': 99}}
-        self.kwargs['two_digit_year_break'] = tdby
+        self.kwargs['two_digit_year_break'] = tdbyb
 
         # Get the expected error message for bad `tag` and evaluate it
         with pytest.raises(KeyError) as kerr:

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -171,7 +171,7 @@ class TestErrors(object):
         assert str(verr).find("Must supply supported_tags and kindats") >= 0
         return
 
-    def test_list_remote_files_bad_tag_inst_id(self):
+    def test_list_remote_files_bad_tag_inst_id_year_dict(self):
         """Test error is thrown if `two_digit_year_break` missing values."""
 
         tdyb = {'': {'not_tag': 99},
@@ -193,7 +193,7 @@ class TestErrors(object):
 
         return
 
-    def test_list_remote_files_bad_tag_inst_id_year_dict(self):
+    def test_list_remote_files_bad_tag_inst_id(self):
         """Test that an error is thrown if None is passed through."""
 
         # Get the expected error message and evaluate it

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -171,30 +171,6 @@ class TestErrors(object):
         assert str(verr).find("Must supply supported_tags and kindats") >= 0
         return
 
-    def test_list_remote_files_bad_tag_inst_id_year_dict(self):
-        """Test error is thrown if `two_digit_year_break` missing values."""
-
-        tdyb = {'tag1': {'testing': 99}}
-        self.kwargs['two_digit_year_break'] = tdyb
-
-        # Get the expected error message for bad `tag` and evaluate it
-        with pytest.raises(KeyError) as kerr:
-            general.list_remote_files('tag', 'testing', **self.kwargs)
-
-        assert str(kerr).find('break` does not include key') >= 0
-
-        tdyb = {'testing': {'tag1': 99}}
-        self.kwargs['two_digit_year_break'] = tdyb
-
-        # Get the expected error message for bad `inst_id` and evaluate it
-        with pytest.raises(KeyError) as kerr:
-            general.list_remote_files('tag', 'testing',
-                                      **self.kwargs)
-
-        assert str(kerr).find('[inst_id]` does not include key') >= 0
-
-        return
-
     def test_list_remote_files_bad_tag_inst_id(self):
         """Test that an error is thrown if None is passed through."""
 

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -174,19 +174,21 @@ class TestErrors(object):
     def test_list_remote_files_bad_tag_inst_id_year_dict(self):
         """Test error is thrown if `two_digit_year_break` missing values."""
 
-        tdyb = {'': {'not_tag': 99},
-                'not_id': {'tag': 99}}
+        tdyb = {'tag1': {'testing': 99}}
         self.kwargs['two_digit_year_break'] = tdyb
 
         # Get the expected error message for bad `tag` and evaluate it
         with pytest.raises(KeyError) as kerr:
-            general.list_remote_files('testing', 'tag', **self.kwargs)
+            general.list_remote_files('tag', 'testing', **self.kwargs)
 
         assert str(kerr).find('break` does not include key') >= 0
 
+        tdyb = {'testing': {'tag1': 99}}
+        self.kwargs['two_digit_year_break'] = tdyb
+
         # Get the expected error message for bad `inst_id` and evaluate it
         with pytest.raises(KeyError) as kerr:
-            general.list_remote_files('testing', 'tag', inst_id='id',
+            general.list_remote_files('tag', 'testing',
                                       **self.kwargs)
 
         assert str(kerr).find('[inst_id]` does not include key') >= 0

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -202,6 +202,7 @@ class TestErrors(object):
 
         assert str(kerr).find('not_tag') >= 0
         return
+
     @pytest.mark.parametrize("in_key, in_val, test_verr", [
         ("kindat", None, "Must supply Madrigal experiment code"),
         ("file_type", "not a file", "Unknown file format")])

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -176,7 +176,7 @@ class TestErrors(object):
 
         tdyb = {'': {'not_tag': 99},
                 'not_id': {'tag': 99}}
-        self.kwargs['two_digit_year_break'] = tdbyb
+        self.kwargs['two_digit_year_break'] = tdyb
 
         # Get the expected error message for bad `tag` and evaluate it
         with pytest.raises(KeyError) as kerr:

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -172,6 +172,28 @@ class TestErrors(object):
         return
 
     def test_list_remote_files_bad_tag_inst_id(self):
+        """Test error is thrown if `two_digit_year_break` missing values."""
+
+        tdyb = {'': {'not_tag': 99},
+                'not_id': {'tag': 99}}
+        self.kwargs['two_digit_year_break'] = tdby
+
+        # Get the expected error message for bad `tag` and evaluate it
+        with pytest.raises(KeyError) as kerr:
+            general.list_remote_files('testing', 'tag', **self.kwargs)
+
+        assert str(kerr).find('break` does not include key') >= 0
+
+        # Get the expected error message for bad `inst_id` and evaluate it
+        with pytest.raises(KeyError) as kerr:
+            general.list_remote_files('testing', 'tag', inst_id='id',
+                                      **self.kwargs)
+
+        assert str(kerr).find('[inst_id]` does not include key') >= 0
+
+        return
+
+    def test_list_remote_files_bad_tag_inst_id_year_dict(self):
         """Test that an error is thrown if None is passed through."""
 
         # Get the expected error message and evaluate it
@@ -180,7 +202,6 @@ class TestErrors(object):
 
         assert str(kerr).find('not_tag') >= 0
         return
-
     @pytest.mark.parametrize("in_key, in_val, test_verr", [
         ("kindat", None, "Must supply Madrigal experiment code"),
         ("file_type", "not a file", "Unknown file format")])


### PR DESCRIPTION
# Description

Addresses #70 

Fixes use of `remote_file_list` for GNSS TEC `vtec`

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality or documentation)

# How Has This Been Tested?


- Added unit tests for new function errors
- Ran unit tests that originally identified `remote_file_list` issue. Works now.

## Test Configuration
* Operating system: MacOS
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
