### PR TITLE
MAINT: syntax for pytest and pysat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    - Fixed bugs in the coordinate conversion functions
 - Maintenance
    - Updated GitHub action and NEP29 versions
+   - Update pysat instrument testing suite, pytest syntax
 
 ## [0.0.4] - 2021-06-11
 - Made changes to structure to comply with updates in pysat 3.0.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ for the Space Physics community.  This module officially supports Python 3.7+.
 | Common modules | Community modules |
 | -------------- | ----------------- |
 | h5py           | madrigalWeb       |
-| numpy          | pysat >= 3.0.0    |
+| numpy          | pysat >= 3.0.3    |
 | pandas         |                   |
 | xarray         |                   |
 

--- a/pysatMadrigal/tests/test_instruments.py
+++ b/pysatMadrigal/tests/test_instruments.py
@@ -21,7 +21,8 @@ user_info = {module: {'user': 'pysat+CI_tests',
 # Tell the standard tests which instruments to run each test on.
 # Need to return instrument list for custom tests.
 instruments = clslib.InstLibTests.initialize_test_package(
-    clslib.InstLibTests, inst_loc=pysatNASA.instruments, user_info=user_info)
+    clslib.InstLibTests, inst_loc=pysatMadrigal.instruments,
+    user_info=user_info)
 
 
 class TestInstruments(clslib.InstLibTests):

--- a/pysatMadrigal/tests/test_instruments.py
+++ b/pysatMadrigal/tests/test_instruments.py
@@ -5,12 +5,8 @@
 # ----------------------------------------------------------------------------
 """Unit tests for the Instruments."""
 
-import tempfile
-import pytest
-
-import pysat
-from pysat.utils import generate_instrument_list
-from pysat.tests.instrument_test_class import InstTestClass
+# Import the test classes from pysat
+from pysat.tests.classes import cls_instrument_library as clslib
 
 import pysatMadrigal
 
@@ -22,55 +18,18 @@ user_info = {module: {'user': 'pysat+CI_tests',
                       'password': 'pysat.developers@gmail.com'}
              for module in pysatMadrigal.instruments.__all__}
 
-# Developers for instrument libraries should update the following line to
-# point to their own subpackage location
-# e.g.,
-# instruments = generate_instrument_list(inst_loc=mypackage.inst)
-# If user and password info supplied, use the following instead
-# instruments = generate_instrument_list(inst_loc=mypackage.inst,
-#                                        user_info=user_info)
-instruments = generate_instrument_list(inst_loc=pysatMadrigal.instruments,
-                                       user_info=user_info)
-method_list = [func for func in dir(InstTestClass)
-               if callable(getattr(InstTestClass, func))]
-
-# Search tests for iteration via pytestmark, update instrument list
-for method in method_list:
-    if hasattr(getattr(InstTestClass, method), 'pytestmark'):
-        # Get list of names of pytestmarks
-        mark_name = [mod_mark.name for mod_mark
-                     in getattr(InstTestClass, method).pytestmark]
-
-        # Add instruments from your library
-        if 'all_inst' in mark_name:
-            mark = pytest.mark.parametrize("inst_name", instruments['names'])
-            getattr(InstTestClass, method).pytestmark.append(mark)
-        elif 'download' in mark_name:
-            mark = pytest.mark.parametrize("inst_dict",
-                                           instruments['download'])
-            getattr(InstTestClass, method).pytestmark.append(mark)
-        elif 'no_download' in mark_name:
-            mark = pytest.mark.parametrize("inst_dict",
-                                           instruments['no_download'])
-            getattr(InstTestClass, method).pytestmark.append(mark)
+# Tell the standard tests which instruments to run each test on.
+# Need to return instrument list for custom tests.
+instruments = clslib.InstLibTests.initialize_test_package(
+    clslib.InstLibTests, inst_loc=pysatNASA.instruments, user_info=user_info)
 
 
-class TestInstruments(InstTestClass):
-    def setup_class(self):
-        """Initialize the testing setup."""
-        # Make sure to use a temporary directory so that the user's setup is
-        # not altered
-        self.tempdir = tempfile.TemporaryDirectory()
-        self.saved_path = pysat.params['data_dirs']
-        pysat.params.data['data_dirs'] = [self.tempdir.name]
+class TestInstruments(clslib.InstLibTests):
+    """Main class for instrument tests.
 
-        # Point to the Instrument subpackage location
-        self.inst_loc = pysatMadrigal.instruments
-        return
+    Note
+    ----
+    All standard tests, setup, and teardown inherited from the core pysat
+    instrument test class.
 
-    def teardown_class(self):
-        """Clean up previous testing."""
-        pysat.params.data['data_dirs'] = self.saved_path
-        self.tempdir.cleanup()
-        del self.inst_loc, self.saved_path, self.tempdir
-        return
+    """

--- a/pysatMadrigal/tests/test_methods_general.py
+++ b/pysatMadrigal/tests/test_methods_general.py
@@ -26,12 +26,12 @@ from pysatMadrigal.instruments.methods import general
 class TestLocal(object):
     """Unit tests for general methods that run locally."""
 
-    def setup(self):
+    def setup_method(self):
         """Runs before every method to create a clean testing setup."""
         self.out = None
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Runs after every method to clean up previous testing."""
         del self.out
         return
@@ -223,7 +223,7 @@ class TestLocal(object):
 class TestErrors(object):
     """Tests for errors raised by the general methods."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         self.kwargs = {'inst_code': '10',
                        'user': 'username',
@@ -232,7 +232,7 @@ class TestErrors(object):
                        'supported_tags': {'testing': {'tag': 'file%Y%m%d.nc'}}}
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
         del self.kwargs
         return
@@ -353,7 +353,7 @@ class TestErrors(object):
 class TestSimpleFiles(object):
     """Tests for general methods with simple files."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
 
         # Create testing directory
@@ -370,7 +370,7 @@ class TestSimpleFiles(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
 
         # Remove the temporary directory and file
@@ -494,7 +494,7 @@ class TestSimpleFiles(object):
 class TestNetCDFFiles(object):
     """Tests for general methods with NetCDF files."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
 
         # Create testing directory
@@ -513,7 +513,7 @@ class TestNetCDFFiles(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
 
         # Remove the temporary directory and file
@@ -644,7 +644,7 @@ class TestNetCDFFiles(object):
 class TestListFiles(object):
     """Tests for general methods function `list_files`."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
 
         # Initalize a pysat Instrument
@@ -664,7 +664,7 @@ class TestListFiles(object):
 
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
 
         # Remove the temporary file, if it exists
@@ -800,14 +800,14 @@ class TestListFiles(object):
 class TestMadrigalExp(object):
     """Unit tests for the MadrigalWeb functions that use MadrigalExperiment."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing environment."""
         self.exp = None
         self.start = dt.datetime(1950, 1, 1)
         self.stop = dt.datetime.utcnow()
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Tear down the existing testing environment."""
         del self.exp, self.start, self.stop
         return

--- a/pysatMadrigal/tests/test_methods_gnss.py
+++ b/pysatMadrigal/tests/test_methods_gnss.py
@@ -13,12 +13,12 @@ from pysatMadrigal.instruments.methods import gnss
 class TestGNSSRefs(object):
     """Test the acknowledgements and references for the JRO instruments."""
 
-    def setup(self):
+    def setup_method(self):
         """Run before every method to create a clean testing setup."""
         self.out = None
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Run after every method to clean up previous testing."""
         del self.out
         return

--- a/pysatMadrigal/tests/test_methods_jro.py
+++ b/pysatMadrigal/tests/test_methods_jro.py
@@ -17,12 +17,12 @@ from pysatMadrigal.instruments.methods import jro
 class TestJRORefs(object):
     """Test the acknowledgements and references for the JRO instruments."""
 
-    def setup(self):
+    def setup_method(self):
         """Run before every method to create a clean testing setup."""
         self.out = None
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Run after every method to clean up previous testing."""
         del self.out
         return
@@ -40,7 +40,7 @@ class TestJRORefs(object):
 class TestJROCalcLoc(object):
     """Test the JRO support function `calc_measurement_loc`."""
 
-    def setup(self):
+    def setup_method(self):
         """Run before every method to create a clean testing setup."""
         self.inst = pysat.Instrument('pysat', 'testing_xarray', num_samples=100)
         self.stime = pysat.instruments.pysat_testing_xarray._test_dates['']['']
@@ -55,7 +55,7 @@ class TestJROCalcLoc(object):
         self.tol = 1.0e-4
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Run after every method to clean up previous testing."""
         del self.inst, self.stime, self.az, self.el
         del self.lat_min, self.lat_max, self.lon_min, self.lon_max, self.tol

--- a/pysatMadrigal/tests/test_utils_coords.py
+++ b/pysatMadrigal/tests/test_utils_coords.py
@@ -9,14 +9,14 @@ from pysatMadrigal.utils import coords
 class TestGeodeticGeocentric():
     """Unit tests for geodetic to geocentric conversion methods."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         self.val = {'lat': 45.0, 'lon': 8.0, 'az': 52.0, 'el': 63.0}
         self.out = None
         self.loc = None
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
         del self.val, self.out, self.loc
         return
@@ -111,7 +111,7 @@ class TestGeodeticGeocentric():
 class TestGeodeticGeocentricArray(TestGeodeticGeocentric):
     """Unit tests for geodetic to geocentric array conversion."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         arr = np.ones(shape=(10,), dtype=float)
         self.val = {'lat': 45.0 * arr,
@@ -122,7 +122,7 @@ class TestGeodeticGeocentricArray(TestGeodeticGeocentric):
         self.loc = None
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
         del self.val, self.out, self.loc
         return
@@ -131,7 +131,7 @@ class TestGeodeticGeocentricArray(TestGeodeticGeocentric):
 class TestSphereCartesian():
     """Unit tests for spherical/cartesian conversions."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         self.val = {'az': 45.0, 'el': 30.0, 'r': 1.0,
                     'x': 0.6123724356957946,
@@ -141,7 +141,7 @@ class TestSphereCartesian():
         self.loc = None
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
         del self.val, self.out, self.loc
         return
@@ -186,7 +186,7 @@ class TestSphereCartesian():
 class TestSphereCartesianArray(TestSphereCartesian):
     """Unit tests for spherical/cartesian coordinate conversion with arrays."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         arr = np.ones(shape=(10,), dtype=float)
         self.val = {'az': 45.0 * arr, 'el': 30.0 * arr, 'r': 1.0 * arr,
@@ -197,7 +197,7 @@ class TestSphereCartesianArray(TestSphereCartesian):
         self.loc = None
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
         del self.val, self.out, self.loc
         return
@@ -206,7 +206,7 @@ class TestSphereCartesianArray(TestSphereCartesian):
 class TestGlobalLocal():
     """Unit tests for global/local conversions."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         self.val = {'x': 7000.0, 'y': 8000.0, 'z': 9000.0,
                     'lat': 37.5, 'lon': 289.0, 'rad': 6380.0}
@@ -214,7 +214,7 @@ class TestGlobalLocal():
         self.loc = None
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
         del self.val, self.out, self.loc
         return
@@ -270,7 +270,7 @@ class TestGlobalLocal():
 class TestGlobalLocalArray(TestGlobalLocal):
     """Unit tests for global/local conversion with arrays."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         arr = np.ones(shape=(10,), dtype=float)
         self.val = {'x': 7000.0 * arr, 'y': 8000.0 * arr, 'z': 9000.0 * arr,
@@ -279,7 +279,7 @@ class TestGlobalLocalArray(TestGlobalLocal):
         self.loc = None
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
         del self.val, self.out, self.loc
         return
@@ -288,7 +288,7 @@ class TestGlobalLocalArray(TestGlobalLocal):
 class TestLocalHorizontalGlobal():
     """Tests for local horizontal to global geo and back."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         self.val = {'az': 30.0, 'el': 45.0, 'dist': 1000.0,
                     'lat': 45.0, 'lon': 0.0, 'alt': 400.0}
@@ -296,7 +296,7 @@ class TestLocalHorizontalGlobal():
         self.loc = None
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
         del self.val, self.out, self.loc
         return
@@ -330,7 +330,7 @@ class TestLocalHorizontalGlobal():
 class TestLocalHorizontalGlobalArray(TestLocalHorizontalGlobal):
     """Tests for local horizontal to global geo and back."""
 
-    def setup(self):
+    def setup_method(self):
         """Create a clean testing setup."""
         arr = np.ones(shape=(10,), dtype=float)
         self.val = {'az': 30.0 * arr, 'el': 45.0 * arr, 'dist': 1000.0 * arr,
@@ -339,7 +339,7 @@ class TestLocalHorizontalGlobalArray(TestLocalHorizontalGlobal):
         self.loc = None
         return
 
-    def teardown(self):
+    def teardown_method(self):
         """Clean up previous testing."""
         del self.val, self.out, self.loc
         return

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ classifiers =
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
   Operating System :: MacOS :: MacOS X
   Operating System :: POSIX :: Linux
 license_file = LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,5 +62,6 @@ markers =
     all_inst: tests all instruments
     download: tests for downloadable instruments
     no_download: tests for instruments without download support
+    load_options: tests for instruments with additional options
     first: first tests to run
     second: second tests to run


### PR DESCRIPTION
# Description

Addresses pysat/pysat#1053

Updates test syntax to be compatible with changes in pytest (`setup_method`, `teardown_method`) and pysat (streamline the instrument tests).

# Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Github Actions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
