### PR TITLE
Update pysat remote file list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
      between '.' delimiters, required for some Madrigal file formats
    * Standardized the Instrument method kwarg defaults
    * Added 'site' tag to the GNSS TEC Instrument
+   * Added a 'dmsp_ssj' instrument for Auroral Boundary Index data
    * Added support for varied use of `two_digit_year_break` to
      `methods.general.list_remote_files`
    * Implemented `two_digit_year_break` support for `vtec` GNSS TEC Instrument
@@ -29,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added quick-fail for main pytest command
 * Bug
    * Fixed bugs in the coordinate conversion functions
+   * Fixed bug in the general download function that sets the stop date
 * Maintenance
    * Updated GitHub action and NEP29 versions
    * Updated the minimum Madrigal version to allow HDF4 downloads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Updated the minimum Madrigal version to allow HDF4 downloads
    * Update pysat instrument testing suite, pytest syntax
    * Add manual GitHub Actions tests for pysat RC
+   * Removed code needed to work around pysat bugs
 
 [0.0.4] - 2021-06-11
 --------------------

--- a/docs/supported_instruments.rst
+++ b/docs/supported_instruments.rst
@@ -11,6 +11,16 @@ Meter (IVM) Madrigal data.
 .. automodule:: pysatMadrigal.instruments.dmsp_ivm
    :members:
 
+DMSP_SSJ
+--------
+
+Supports the Defense Meteorological Satelitte Program (DMSP) Special Sensor J
+(SSJ) Madrigal data.
+
+
+.. automodule:: pysatMadrigal.instruments.dmsp_ssj
+   :members:
+
 GNSS_TEC
 --------
 

--- a/pysatMadrigal/instruments/__init__.py
+++ b/pysatMadrigal/instruments/__init__.py
@@ -1,5 +1,6 @@
 # Import Madrigal instruments
 from pysatMadrigal.instruments import dmsp_ivm
+from pysatMadrigal.instruments import dmsp_ssj
 from pysatMadrigal.instruments import gnss_tec
 from pysatMadrigal.instruments import jro_isr
 from pysatMadrigal.instruments import madrigal_pandas
@@ -8,4 +9,4 @@ from pysatMadrigal.instruments import madrigal_pandas
 from pysatMadrigal.instruments import methods  # noqa F401
 
 # Define variable name with all available instruments
-__all__ = ['dmsp_ivm', 'gnss_tec', 'jro_isr', 'madrigal_pandas']
+__all__ = ['dmsp_ivm', 'dmsp_ssj', 'gnss_tec', 'jro_isr', 'madrigal_pandas']

--- a/pysatMadrigal/instruments/dmsp_ssj.py
+++ b/pysatMadrigal/instruments/dmsp_ssj.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python
+# Full license can be found in License.md
+# Full author list can be found in .zenodo.json file
+# DOI:10.5281/zenodo.3824979
+# ----------------------------------------------------------------------------
+# -*- coding: utf-8 -*-
+"""Support the DMSP Special Sensor-J (SSJ) instrument and derived products.
+
+The Defense Meteorological Satellite Program (DMSP) SSJ measures precipitating
+particles using spectrometery. The Auroral Boundary Index (ABI) is automatically
+computed from this data set and marks the midnight equatorward boundary in each
+hemisphere.
+
+Further questions can be addressed to:
+ Gordon Wilson
+ Air Force Research Lab
+ RVBXP
+ 3550 Aberdeen Avenue SE, Bldg 570
+ Kirtland Air Force Base, NM 87117-5776
+ Phone: 505-853-2027
+ e-mail: gordon.wilson@kirtland.af.mil
+or
+ Ernie Holeman (ernestholeman7408@comcast.net)
+
+Please send a copy of all publications that use the Auroral Boundary Index
+(ABI) to Dr. Gordon Wilson at the above address.
+
+
+Properties
+----------
+platform
+    'dmsp'
+name
+    'ssj'
+tag
+    'abi'
+inst_id
+    'f11'
+
+Example
+-------
+::
+
+    import pysat
+    dmsp = pysat.Instrument('dmsp', 'ssj', 'abi', clean_level='clean')
+    dmsp.download(dt.datetime(2017, 12, 30), dt.datetime(2017, 12, 31),
+                  user='Firstname+Lastname', password='email@address.com')
+    dmsp.load(2017, 363)
+
+Note
+----
+Please provide name and email when downloading data with this routine.
+
+"""
+
+import datetime as dt
+import functools
+import numpy as np
+import pandas as pds
+import warnings
+
+from pysat import logger
+from pysat.utils.time import create_date_range
+
+from pysatMadrigal.instruments.methods import dmsp
+from pysatMadrigal.instruments.methods import general
+
+# ----------------------------------------------------------------------------
+# Instrument attributes
+
+platform = 'dmsp'
+name = 'ssj'
+tags = {'abi': 'Midnight Auroral Boundary Index'}
+inst_ids = {'': [tag for tag in tags.keys()]}
+
+pandas_format = True
+
+# Madrigal tags
+madrigal_inst_code = 180
+madrigal_tag = {'': {'abi': '17110'}}
+
+# Local attributes
+dmsp_fname = general.madrigal_file_format_str(madrigal_inst_code)
+supported_tags = {inst_id: {tag: dmsp_fname for tag in inst_ids[inst_id]}
+                  for inst_id in inst_ids.keys()}
+remote_tags = {
+    inst_id: {tag: supported_tags[inst_id][tag].format(file_type='hdf5')
+              for tag in inst_ids[inst_id]} for inst_id in inst_ids.keys()}
+
+# ----------------------------------------------------------------------------
+# Instrument test attributes
+
+_test_dates = {'': {'abi': dt.datetime(1982, 12, 30)}}
+
+# ----------------------------------------------------------------------------
+# Instrument methods
+
+
+def init(self):
+    """Initialize the Instrument object with values specific to DMSP IVM."""
+    self.acknowledgements = ''.join([
+        general.cedar_rules(), '\nThe Air Force Research Laboratory Auroral ',
+        'Boundary Index (ABI) was provided by the United States Air Force ',
+        'Research Laboratory, Kirtland Air Force Base, New Mexico.'])
+
+    logger.info(self.acknowledgements)
+    self.references = dmsp.references(self.name)
+    return
+
+
+def clean(self):
+    """Clean DMSP IVM data cleaned to the specified level.
+
+    Note
+    ----
+    Supports 'clean' and 'dusty'
+
+    'clean' QC == 1
+    'dusty' QC <= 2
+    'dirty' and 'none' allow all QC flags (QC <= 3)
+
+    When called directly by pysat, a clean level of 'none' causes pysat to skip
+    this routine.
+
+    Warnings
+    --------
+    UserWarning
+        If the 'dirty' level is invoked (same as no cleaning)
+
+    """
+    if self.clean_level == 'clean':
+        iclean, = np.where(self['eqb_qc_fl'] <= 1)
+    elif self.clean_level == 'dusty':
+        iclean, = np.where(self['eqb_qc_fl'] <= 2)
+    else:
+        warnings.warn('No quality control level "dirty", using "none"')
+        iclean = None
+
+    # Downselect data based upon cleaning conditions above
+    if iclean is not None:
+        self.data = self[iclean]
+
+    return
+
+
+# ----------------------------------------------------------------------------
+# Instrument functions
+#
+# Use the default Madrigal and pysat methods
+
+# Support listing the local files
+list_files = functools.partial(general.list_files,
+                               supported_tags=supported_tags,
+                               file_cadence=pds.DateOffset(years=1))
+
+# Set the list_remote_files routine
+list_remote_files = functools.partial(general.list_remote_files,
+                                      inst_code=madrigal_inst_code,
+                                      kindats=madrigal_tag,
+                                      supported_tags=remote_tags)
+
+
+# Set the load routine
+def load(fnames, tag='', inst_id=''):
+    """Load DMSP SSJ4 data from Madrigal after accounting for date tags.
+
+    Parameters
+    ----------
+    fnames : array-like
+        Iterable of filename strings, full path, to data files to be loaded.
+        This input is nominally provided by pysat itself.
+    tag : str
+        Tag name used to identify particular data set to be loaded. This input
+        is nominally provided by pysat itself and is not used here. (default='')
+    inst_id : str
+        Instrument ID used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself, and is not used here.
+        (default='')
+
+    Returns
+    -------
+    data : pds.DataFrame or xr.Dataset
+        A pandas DataFrame or xarray Dataset holding the data from the file
+    meta : pysat.Meta
+        Metadata from the file, as well as default values from pysat
+
+    Raises
+    ------
+    ValueError
+       If data columns expected to create the time index are missing or if
+       coordinates are not supplied for all data columns.
+
+    Note
+    ----
+    Currently HDF5 reading breaks if a different file type was used previously
+
+    This routine is called as needed by pysat. It is not intended
+    for direct user interaction.
+
+    """
+    # The ABI data has a yearly cadance, extract the unique filenames to load
+    load_fnames = list()
+    file_dates = list()
+    for fname in fnames:
+        file_dates.append(dt.datetime.strptime(fname[-10:], '%Y-%m-%d'))
+        if fname[0:-11] not in load_fnames:
+            load_fnames.append(fname[0:-11])
+
+    # Load the data and metadata
+    data, meta = general.load(load_fnames, tag=tag, inst_id=inst_id)
+
+    # If there is a date range, downselect here
+    if len(file_dates) > 0:
+        idx, = np.where((data.index >= min(file_dates))
+                        & (data.index < max(file_dates) + dt.timedelta(days=1)))
+        data = data.iloc[idx, :]
+
+    return data, meta
+
+
+def download(date_array, tag='', inst_id='', data_path=None, user=None,
+             password=None, file_type='hdf5'):
+    """Download DMSP SSJ4 data from Madrigal.
+
+    Parameters
+    ----------
+    date_array : array-like
+        list of datetimes to download data for. The sequence of dates need not
+        be contiguous.
+    tag : str
+        Tag identifier used for particular dataset. This input is provided by
+        pysat. (default='')
+    inst_id : str
+        Satellite ID string identifier used for particular dataset. This input
+        is provided by pysat. (default='')
+    data_path : str
+        Path to directory to download data to. (default=None)
+    user : str
+        User string input used for download. Provided by user and passed via
+        pysat. If an account is required for downloads this routine here must
+        error if user not supplied. (default=None)
+    password : str
+        Password for data download. (default=None)
+    file_type : str
+        File format for Madrigal data. (default='hdf5')
+
+    Note
+    ----
+    The user's names should be provided in field user. Ritu Karidhal should
+    be entered as Ritu+Karidhal
+
+    The password field should be the user's email address. These parameters
+    are passed to Madrigal when downloading.
+
+    The affiliation field is set to pysat to enable tracking of pysat
+    downloads.
+
+    """
+    # Ensure the date range is correct
+    if date_array.freq not in ['AS-JAN', 'YS', 'AS']:
+        date_array = create_date_range(
+            dt.datetime(date_array[0].year, 1, 1), date_array[-1], freq='YS')
+
+    # Download the remote files
+    general.download(date_array, inst_code=str(madrigal_inst_code),
+                     kindat=madrigal_tag[inst_id][tag], data_path=data_path,
+                     user=user, password=password, file_type=file_type)
+    return

--- a/pysatMadrigal/instruments/madrigal_pandas.py
+++ b/pysatMadrigal/instruments/madrigal_pandas.py
@@ -75,7 +75,9 @@ platform = 'madrigal'
 name = 'pandas'
 tags = dict()
 pandas_format = True
-excluded_tags = ['8105']  # Pandas-style data that requires special support
+
+# Pandas-style data that requires special support
+excluded_tags = ['8105', '180']
 
 # Assign only tags with pysat-compatible file format strings
 pandas_codes = general.known_madrigal_inst_codes(pandas_format=True)
@@ -102,9 +104,8 @@ supported_tags = {ss: {tag: general.madrigal_file_format_str(tag)
 # Need to sort out test day setting for unit testing, maybe through a remote
 # function
 tag_dates = {'120': dt.datetime(1963, 11, 27), '170': dt.datetime(1998, 7, 1),
-             '180': dt.datetime(2000, 1, 1), '210': dt.datetime(1950, 1, 1),
-             '211': dt.datetime(1978, 1, 1), '212': dt.datetime(1957, 1, 1),
-             '7800': dt.datetime(2009, 11, 10)}
+             '210': dt.datetime(1950, 1, 1), '211': dt.datetime(1978, 1, 1),
+             '212': dt.datetime(1957, 1, 1), '7800': dt.datetime(2009, 11, 10)}
 _test_dates = {'': {tag: tag_dates[tag] if tag in tag_dates.keys()
                     else tag_dates['7800'] for tag in tags.keys()}}
 _test_download = {'': {tag: True for tag in tags.keys()}}

--- a/pysatMadrigal/instruments/methods/dmsp.py
+++ b/pysatMadrigal/instruments/methods/dmsp.py
@@ -32,7 +32,20 @@ def references(name):
                              'SSIES-3) on Spacecraft of the Defense',
                              'Meteorological Satellite Program (Air Force',
                              'Phillips Laboratory, Hanscom AFB, MA, 1994),',
-                             'Vol. 1, p. 25.'))}
+                             'Vol. 1, p. 25.')),
+            'ssj': ''.join(['Gussenhoven, M. S., D. A. Hardy and W. J. Burke, ',
+                            'DMSP/F2 electron observations of equatorward ',
+                            'auroral boundaries and their relationship to ',
+                            'magnetospheric electric fields, J. Geophys. Res.,',
+                            ' 86, 768-778, 1981.\nGussenhoven, M. S., D. A. ',
+                            'Hardy and N. Heinemann, Systematics of the ',
+                            'equatorward diffuse auroral boundary, J. Geophys.',
+                            ' Res., 88, 5692-5708, 1983.\nHardy, D. A., E. ',
+                            'G. Holeman, W. J. Burke, L. C. Gentile and K. H. ',
+                            'Bounar (2008), Probability distributions of ',
+                            'electron precipitation at high magnetic latitudes',
+                            ', Journal of Geophysical Research, Volume 113, ',
+                            'Issue A6, doi10.1029/2007JA012746.'])}
 
     return refs[name]
 

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -1165,13 +1165,6 @@ def list_remote_files(tag, inst_id, inst_code=None, kindats=None, user=None,
     format_str = supported_tags[inst_id][tag]
     kindat = kindats[inst_id][tag]
 
-    # TODO(#1022, pysat) Note default of `pysat.Instrument.remote_file_list`
-    #  for start and stop is None. Setting defaults needed for Madrigal.
-    if start is None:
-        start = dt.datetime(1900, 1, 1)
-    if stop is None:
-        stop = dt.datetime.utcnow()
-
     # Retrieve remote file experiment list
     files = get_remote_filenames(inst_code=inst_code, kindat=kindat, user=user,
                                  password=password, url=url, start=start,

--- a/pysatMadrigal/instruments/methods/general.py
+++ b/pysatMadrigal/instruments/methods/general.py
@@ -883,7 +883,7 @@ def download(date_array, inst_code=None, kindat=None, data_path=None,
     start = date_array.min()
     stop = date_array.max()
     if start == stop:
-        stop += dt.timedelta(days=1)
+        stop = date_array.shift().max()
 
     # Initialize the connection to Madrigal
     logger.info('Connecting to Madrigal')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ madrigalWeb>=2.6
 numpy
 packaging
 pandas
-pysat>=3.0.3
+pysat>=3.1.0
 xarray

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,8 @@ omit = */instruments/templates/*
 [flake8]
 max-line-length = 80
 ignore = W503
+       D200
+       D202
 
 [tool:pytest]
 markers =

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,5 +4,5 @@ m2r2
 numpydoc
 pytest-cov
 pytest-ordering
-sphinx
+sphinx<7.0
 sphinx_rtd_theme


### PR DESCRIPTION
# Description

Removes logic needed to get around pysat behaviour that doesn't recognize the default values of start/stop set outside of the pysat.Instrument for remote_file_list functions.  Requires https://github.com/pysat/pysat/pull/1083 to work.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


```
import pysat

dmsp = pysat.Instrument('dmsp', 'ivm', inst_id='f15')
dmsp.remote_file_list(user='your name', password='your email')
```

I added a RuntimeError to `pysatMadrigal.instruments.general.list_remote_files` when testing to ensure the start/stop times matched the defaults when using this call.

## Test Configuration
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant: pysat https://github.com/pysat/pysat/pull/1083

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
