### PR TITLE
MAINT: GA updates

### DIFF
--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -4,7 +4,7 @@
 
 name: Test install of latest RC from pip
 
-on: [push]
+on: [workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -4,7 +4,7 @@
 
 name: Test install of latest RC from pip
 
-on: [workflow_dispatch]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -1,0 +1,30 @@
+# This workflow will install Python dependencies and the latest RC of pysatNASA from test pypi.
+# This test should be manually run before a pysatMadrigal RC is officially approved and versioned.
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Test install of latest RC from pip
+
+on: [workflow_dispatch]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.10"]  # Keep this version at the highest supported Python version
+
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install standard dependencies
+      run: pip install -r requirements.txt
+
+    - name: Install pysatMadrigal RC
+      run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysatMadrigal

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -4,7 +4,7 @@
 
 name: Test install of latest RC from pip
 
-on: [workflow_dispatch]
+on: [push]
 
 jobs:
   build:
@@ -28,3 +28,13 @@ jobs:
 
     - name: Install pysatMadrigal RC
       run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysatMadrigal
+
+    - name: Set up pysat
+      run: |
+        mkdir pysatData
+        python -c "import pysat; pysat.params['data_dirs'] = 'pysatData'"
+
+    - name: Check that install imports correctly
+      run: |
+        cd ..
+        python -c "import pysatMadrigal; print(pysatMadrigal.__version__)"

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install pysat RC
-      run: pip install --no-deps -i https://test.pypi.org/simple/ pysat
+      run: pip install --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysat
 
     - name: Install standard dependencies
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+[0.1.X] - 2023-XX-XX
+--------------------
+* Maintenance
+  * Add manual GitHub Actions tests for pysatMadrigal RC
+  * Update GitHub Actions workflows for newer versions of pip
+
 [0.1.0] - 2023-04-11
 --------------------
 * Enhancements

--- a/pysatMadrigal/__init__.py
+++ b/pysatMadrigal/__init__.py
@@ -1,3 +1,10 @@
+"""Core library for pysatMadrigal.
+
+This is a library of `pysat` instrument modules and methods designed to support
+instruments archived at the Madrigal portal.
+
+"""
+
 import os
 from pysatMadrigal import instruments  # noqa F401
 from pysatMadrigal import utils  # noqa F401

--- a/pysatMadrigal/__init__.py
+++ b/pysatMadrigal/__init__.py
@@ -1,2 +1,10 @@
+import os
 from pysatMadrigal import instruments  # noqa F401
 from pysatMadrigal import utils  # noqa F401
+
+# set version
+here = os.path.abspath(os.path.dirname(__file__))
+version_filename = os.path.join(here, 'version.txt')
+with open(version_filename, 'r') as version_file:
+    __version__ = version_file.read().strip()
+del here, version_filename, version_file

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,5 +6,5 @@ m2r2
 numpydoc
 pytest-cov
 pytest-ordering
-sphinx
+sphinx<7.0
 sphinx_rtd_theme


### PR DESCRIPTION
# Description

Addresses https://github.com/pysat/pysat/issues/1051. Because pip now builds a wheel locally (by default), it tries to download `setuptools` from test pypi, which isn't there.

Updates RC install options for work with pysat release candidates on test.pypi

Adds a new workflow to test install of the pysatMadrigal RC from test.pypi

# Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality or documentation)

# How Has This Been Tested?

Running manual tests for the RC workflows.

## Test Configuration
* Operating system: GitHUb Actions
* https://github.com/pysat/pysatMadrigal/actions/workflows/pysat_rc.yml
* https://github.com/pysat/pysatMadrigal/actions/workflows/pip_rc_install.yml -- not yet in main, needs to be temporarily set to push

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
