### PR TITLE
Move Madrigal index Instruments to their own sub-modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 [0.1.X] - 2023-XX-XX
 --------------------
 * Enhancements
-  * Moved the OMNI-2 IMF index Instrument from the general Madrigal Pandas
-    instrument into a new one
+  * Moved the OMNI-2 IMF, Dst, and Geomagnetic index Instruments from the
+    general Madrigal Pandas instrument into new ones
   * Moved the NGDC AE index Instrument from the general Madrigal Pandas
     instrument to a new one, fixing the Windows memory issue and a problem
     with duplicated times

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 [0.1.X] - 2023-XX-XX
 --------------------
 * Enhancements
+  * Moved the OMNI-2 IMF index Instrument from the general Madrigal Pandas
+    instrument into a new one
   * Moved the NGDC AE index Instrument from the general Madrigal Pandas
     instrument to a new one, fixing the Windows memory issue and a problem
     with duplicated times

--- a/docs/supported_instruments.rst
+++ b/docs/supported_instruments.rst
@@ -35,9 +35,9 @@ JRO_ISR
 -------
 
 The incoherent scatter radar (ISR) at the
-`Jicamarca Radio Observatory <http://jro.igp.gob.pe/english/>`_ regularly
-measures the velocity, density, and other ionospheric characteristics near the
-magnetic equator over Peru.
+`Jicamarca Radio Observatory <https://www.igp.gob.pe/observatorios/radio-observatorio-jicamarca/?page_id=6609>`_
+regularly measures the velocity, density, and other ionospheric characteristics
+near the magnetic equator over Peru.
 
 .. automodule:: pysatMadrigal.instruments.jro_isr
    :members:

--- a/docs/supported_instruments.rst
+++ b/docs/supported_instruments.rst
@@ -50,7 +50,7 @@ A general instrument for Madrigal time-series data.  This
 :py:class:`pysat.Instrument` uses Madrigal instrument codes and kindats to
 support the use of any of the Madrigal time-series data sets.  There are some
 further constraints in that the data set's Madrigal naming convention must be
-parsable by pysat.  Currently nine Madrigal instrument codes are supported by
+parsable by pysat.  Currently four Madrigal instrument codes are supported by
 this :py:class:`pysat.Instrument`.  When possible, using a specific instrument
 module is recommended, since that instrument module will have additional
 support (e.g., cleaning methods, experiment acknowledgements, and references).
@@ -72,4 +72,15 @@ time period may be loaded.
    :members:
 
 
-      
+OMNI2_IMF
+---------
+
+An instrument for the interplanetary magnetic field (IMF) data from Omni 2. The
+data starts in 1963 and the entire data set is contained in a single file.  The
+file is occasionally updated, and so obtaining the most recent data means that
+all historic data must also be downloaded (or re-downloaded). OMNI data may
+also be obtained more directly using
+`pysatNASA <https://pysatnasa.readthedocs.io/en/latest/supported_instruments.html#omni-hro>`_.
+
+.. automodule:: pysatMadrigal.instruments.omni2_imf
+   :members:

--- a/docs/supported_instruments.rst
+++ b/docs/supported_instruments.rst
@@ -43,6 +43,32 @@ magnetic equator over Peru.
    :members:
 
 
+Madrigal_Dst
+------------
+
+An instrument for the Madrigal Dst index data.  This data set spans the years
+of 1957 through a period close to today, with all data saved in a single file.
+Because of this, you only need to download the data once and any desired time
+period may be loaded (unless you require a time between your last download and
+now).
+
+.. automodule:: pysatMadrigal.instruments.madrigal_dst
+   :members:
+
+
+Madrigal_Geoind
+---------------
+
+An instrument for the Madrigal geomagnetic index data.  This data set spans the
+years of 1950 through a period close to today, with all data saved in a single
+file. Because of this, you only need to download the data once and any desired
+time period may be loaded (unless you require a time between your last download
+and now).
+
+.. automodule:: pysatMadrigal.instruments.madrigal_geoind
+   :members:
+
+
 Madrigal_Pandas
 ---------------
 
@@ -50,7 +76,7 @@ A general instrument for Madrigal time-series data.  This
 :py:class:`pysat.Instrument` uses Madrigal instrument codes and kindats to
 support the use of any of the Madrigal time-series data sets.  There are some
 further constraints in that the data set's Madrigal naming convention must be
-parsable by pysat.  Currently four Madrigal instrument codes are supported by
+parsable by pysat.  Currently three Madrigal instrument codes are supported by
 this :py:class:`pysat.Instrument`.  When possible, using a specific instrument
 module is recommended, since that instrument module will have additional
 support (e.g., cleaning methods, experiment acknowledgements, and references).

--- a/pysatMadrigal/instruments/__init__.py
+++ b/pysatMadrigal/instruments/__init__.py
@@ -9,9 +9,9 @@ from pysatMadrigal.instruments import dmsp_ivm
 from pysatMadrigal.instruments import dmsp_ssj
 from pysatMadrigal.instruments import gnss_tec
 from pysatMadrigal.instruments import jro_isr
-from pysatMadrigal.instruments import madrigal_pandas
 from pysatMadrigal.instruments import madrigal_dst
 from pysatMadrigal.instruments import madrigal_geoind
+from pysatMadrigal.instruments import madrigal_pandas
 from pysatMadrigal.instruments import ngdc_ae
 from pysatMadrigal.instruments import omni2_imf
 
@@ -19,5 +19,5 @@ from pysatMadrigal.instruments import omni2_imf
 from pysatMadrigal.instruments import methods  # noqa F401
 
 # Define variable name with all available instruments
-__all__ = ['dmsp_ivm', 'dmsp_ssj', 'gnss_tec', 'jro_isr', 'madrigal_pandas',
-           'madrigal_dst', 'madrigal_geoind', 'ngdc_ae', 'omni2_imf']
+__all__ = ['dmsp_ivm', 'dmsp_ssj', 'gnss_tec', 'jro_isr', 'madrigal_dst',
+           'madrigal_geoind', 'madrigal_pandas', 'ngdc_ae', 'omni2_imf']

--- a/pysatMadrigal/instruments/__init__.py
+++ b/pysatMadrigal/instruments/__init__.py
@@ -10,11 +10,14 @@ from pysatMadrigal.instruments import dmsp_ssj
 from pysatMadrigal.instruments import gnss_tec
 from pysatMadrigal.instruments import jro_isr
 from pysatMadrigal.instruments import madrigal_pandas
+from pysatMadrigal.instruments import madrigal_dst
+from pysatMadrigal.instruments import madrigal_geoind
 from pysatMadrigal.instruments import ngdc_ae
+from pysatMadrigal.instruments import omni2_imf
 
 # Import Madrigal methods
 from pysatMadrigal.instruments import methods  # noqa F401
 
 # Define variable name with all available instruments
 __all__ = ['dmsp_ivm', 'dmsp_ssj', 'gnss_tec', 'jro_isr', 'madrigal_pandas',
-           'ngdc_ae']
+           'madrigal_dst', 'madrigal_geoind', 'ngdc_ae', 'omni2_imf']

--- a/pysatMadrigal/instruments/madrigal_dst.py
+++ b/pysatMadrigal/instruments/madrigal_dst.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+# Full license can be found in License.md
+# Full author list can be found in .zenodo.json file
+# DOI:10.5281/zenodo.3824979
+# ----------------------------------------------------------------------------
+# -*- coding: utf-8 -*-.
+"""Supports access to Dst data archieved at Madrigal.
+
+Properties
+----------
+platform
+    'madrigal'
+name
+    'dst'
+tag
+    None supported
+inst_id
+    None supported
+
+Note
+----
+Please provide name (user) and email (password) when downloading data with this
+routine.
+
+Warnings
+--------
+The entire data set (1 Jan 1597 through a period close to the recent day) is
+provided in a single file on Madrigal.
+
+Examples
+--------
+::
+
+
+    import datetime as dt
+    import pysat
+    import pysatMadrigal as py_mad
+
+    # Download Dst data from Madrigal
+    dst = pysat.Instrument(inst_module=py_mad.instruments.madrigal_dst)
+    dst.download(start=py_mad.instruments.madrigal_dst.madrigal_start,
+                 user='Firstname+Lastname', password='email@address.com')
+    dst.load(date=dt.datetime(1981, 1, 1))
+
+"""
+
+import datetime as dt
+import functools
+
+import pysat
+
+from pysatMadrigal.instruments.methods import general
+
+# ----------------------------------------------------------------------------
+# Instrument attributes
+
+platform = 'madrigal'
+name = 'dst'
+tags = {'': ''}
+inst_ids = {'': list(tags.keys())}
+pandas_format = True
+
+# Madrigal tags and limits
+madrigal_inst_code = 212
+madrigal_tag = {'': {'': "30006"}}
+madrigal_start = dt.datetime(1957, 1, 1)
+madrigal_end = dt.datetime.utcnow()
+
+# Local attributes
+#
+# Need a way to get the filename strings for a particular instrument unless
+# wildcards start working
+supported_tags = {
+    inst_id: {tag: general.madrigal_file_format_str(madrigal_inst_code,
+                                                    verbose=False)
+              for tag in inst_ids[inst_id]} for inst_id in inst_ids.keys()}
+remote_tags = {ss: {kk: supported_tags[ss][kk].format(file_type='hdf5')
+                    for kk in inst_ids[ss]} for ss in inst_ids.keys()}
+
+# ----------------------------------------------------------------------------
+# Instrument test attributes
+
+_test_dates = {inst_id: {tag: madrigal_start for tag in inst_ids[inst_id]}
+               for inst_id in inst_ids.keys()}
+_test_download = {inst_id: {tag: True for tag in inst_ids[inst_id]}
+                  for inst_id in inst_ids.keys()}
+_clean_warn = {inst_id: {tag: {clvl: [('logger', 'WARN',
+                                       "No cleaning available", clvl)]
+                               for clvl in ['clean', 'dusty', 'dirty']}
+                         for tag in inst_ids[inst_id]}
+               for inst_id in inst_ids.keys()}
+
+# ----------------------------------------------------------------------------
+# Instrument methods
+
+
+def init(self):
+    """Initialize the Instrument object in support of Madrigal access.
+
+    Parameters
+    ----------
+    kindat : str
+        Madrigal instrument experiment code(s). (default='')
+
+    """
+    # Set the standard pysat attributes
+    self.acknowledgements = general.cedar_rules()
+    self.references = ''.join(['See referenece list and publication at: ',
+                               'Sugiura M. and T. Kamei, http://',
+                               'wdc.kugi.kyoto-u.ac.jp/dstdir/dst2/',
+                               'onDstindex.html, last updated June 1991, ',
+                               'accessed Dec 2020'])
+
+    # Remind the user of the Rules of the Road
+    pysat.logger.info(self.acknowledgements)
+    return
+
+
+def clean(self):
+    """Raise warning that cleaning is not needed for the OMNI2 data.
+
+    Note
+    ----
+    Supports 'clean', 'dusty', 'dirty' in the sense that it prints
+    a message noting there is no cleaning.
+    'None' is also supported as it signifies no cleaning.
+
+    Routine is called by pysat, and not by the end user directly.
+
+    """
+    pysat.logger.warning("No cleaning available for the Madrigal Dst")
+
+    return
+
+
+# ----------------------------------------------------------------------------
+# Instrument functions
+#
+# Use the default Madrigal and pysat methods
+file_cadence = madrigal_end - madrigal_start
+two_digit_year_break = 50
+
+# Set the download routine
+download = functools.partial(general.download,
+                             inst_code=str(madrigal_inst_code),
+                             kindat=madrigal_tag[''][''])
+
+# Set the list routine
+list_files = functools.partial(general.list_files,
+                               supported_tags=supported_tags,
+                               file_cadence=file_cadence,
+                               two_digit_year_break=two_digit_year_break)
+
+# Set list_remote_files routine
+list_remote_files = functools.partial(general.list_remote_files,
+                                      supported_tags=remote_tags,
+                                      inst_code=madrigal_inst_code,
+                                      kindats=madrigal_tag,
+                                      two_digit_year_break=two_digit_year_break)
+
+
+def load(fnames, tag='', inst_id=''):
+    """Load the Madrigal Dst data.
+
+    Parameters
+    -----------
+    fnames : list
+        List of filenames
+    tag : str
+        tag name used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself. (default='')
+    inst_id : str
+        Instrument ID used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself. (default='')
+
+    Returns
+    --------
+    data : pds.DataFrame
+        Object containing IMF data
+    meta : pysat.Meta
+        Object containing metadata such as column names and units
+
+    Raises
+    ------
+    ValueError
+        Unexpected time variable names
+
+    """
+    # Cycle through all the filenames, getting the desired start and stop times
+    fstart = None
+    fstop = None
+    for fname_date in fnames:
+        # Split the date from the filename
+        fname = fname_date[:-11]
+        fdate = dt.datetime.strptime(fname_date[-10:], '%Y-%m-%d')
+        fstop = fdate
+
+        if fstart is None:
+            fstart = fdate
+
+    fstop += dt.timedelta(days=1)
+
+    # There is only one file for this Instrument
+    data, meta = general.load([fname], tag=tag, inst_id=inst_id)
+
+    # Select the data for the desired time period
+    data = data[fstart:fstop]
+
+    return data, meta

--- a/pysatMadrigal/instruments/madrigal_geoind.py
+++ b/pysatMadrigal/instruments/madrigal_geoind.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+# Full license can be found in License.md
+# Full author list can be found in .zenodo.json file
+# DOI:10.5281/zenodo.3824979
+# ----------------------------------------------------------------------------
+# -*- coding: utf-8 -*-.
+"""Supports access to F10.7, Kp, and Ap data archieved at Madrigal.
+
+Properties
+----------
+platform
+    'madrigal'
+name
+    'geoind'
+tag
+    None supported
+inst_id
+    None supported
+
+Note
+----
+Please provide name (user) and email (password) when downloading data with this
+routine.
+
+Warnings
+--------
+The entire data set (1 Jan 1950 through 31 Dec 1987) is provided in a single
+file on Madrigal.
+
+Examples
+--------
+::
+
+
+    import datetime as dt
+    import pysat
+    import pysatMadrigal as py_mad
+
+    # Download geophysical indices from Madrigal
+    gind = pysat.Instrument(inst_module=py_mad.instruments.madrigal_geoind)
+    gind.download(start=py_mad.instruments.madrigal_geoind.madrigal_start,
+                  user='Firstname+Lastname', password='email@address.com')
+    gind.load(date=dt.datetime(1981, 1, 1))
+
+"""
+
+import datetime as dt
+import functools
+
+import pysat
+
+from pysatMadrigal.instruments.methods import general
+
+# ----------------------------------------------------------------------------
+# Instrument attributes
+
+platform = 'madrigal'
+name = 'geoind'
+tags = {'': ''}
+inst_ids = {'': list(tags.keys())}
+pandas_format = True
+
+# Madrigal tags and limits
+madrigal_inst_code = 210
+madrigal_tag = {'': {'': "30007"}}
+madrigal_start = dt.datetime(1950, 1, 1)
+madrigal_end = dt.datetime.utcnow()
+
+# Local attributes
+#
+# Need a way to get the filename strings for a particular instrument unless
+# wildcards start working
+supported_tags = {
+    inst_id: {tag: general.madrigal_file_format_str(madrigal_inst_code,
+                                                    verbose=False)
+              for tag in inst_ids[inst_id]} for inst_id in inst_ids.keys()}
+remote_tags = {ss: {kk: supported_tags[ss][kk].format(file_type='hdf5')
+                    for kk in inst_ids[ss]} for ss in inst_ids.keys()}
+
+# ----------------------------------------------------------------------------
+# Instrument test attributes
+
+_test_dates = {inst_id: {tag: madrigal_start for tag in inst_ids[inst_id]}
+               for inst_id in inst_ids.keys()}
+_test_download = {inst_id: {tag: True for tag in inst_ids[inst_id]}
+                  for inst_id in inst_ids.keys()}
+_clean_warn = {inst_id: {tag: {clvl: [('logger', 'WARN',
+                                       "No cleaning available", clvl)]
+                               for clvl in ['clean', 'dusty', 'dirty']}
+                         for tag in inst_ids[inst_id]}
+               for inst_id in inst_ids.keys()}
+
+# ----------------------------------------------------------------------------
+# Instrument methods
+
+
+def init(self):
+    """Initialize the Instrument object in support of Madrigal access.
+
+    Parameters
+    ----------
+    kindat : str
+        Madrigal instrument experiment code(s). (default='')
+
+    """
+    # Set the standard pysat attributes
+    self.acknowledgements = general.cedar_rules()
+    self.references = "\n".join(
+        [''.join(["Covington, A.E. (1948), Solar noise observations on 10.7 ",
+                  "centimeters Solar noise observations on 10.7 centimeters,",
+                  " Proceedings of the IRE, 36(44), p 454-457."]),
+         ''.join(["J. Bartels, The technique of scaling indices K and Q of ",
+                  "geomagnetic activity, Ann. Intern. Geophys. Year 4, ",
+                  "215-226, 1957."]),
+         ''.join(["J. Bartels, The geomagnetic measures for the time-",
+                  "variations of solar corpuscular radiation, described for ",
+                  "use in correlation studies in other geophysical fields, ",
+                  "Ann. Intern. Geophys. Year 4, 227-236, 1957."]),
+         ''.join(["P.N. Mayaud, Derivation, Meaning and Use of Geomagnetic ",
+                  "Indices, Geophysical Monograph 22, Am. Geophys. Union, ",
+                  "Washington D.C., 1980."]),
+         ''.join(["G.K. Rangarajan, Indices of magnetic activity, in ",
+                  "Geomagnetism, edited by I.A. Jacobs, Academic, San Diego,",
+                  " 1989."]),
+         ''.join(["M. Menvielle and A. Berthelier, The K-derived planetary ",
+                  "indices: description and availability, Rev. Geophys. 29, ",
+                  "3, 415-432, 1991."])])
+
+    # Remind the user of the Rules of the Road
+    pysat.logger.info(self.acknowledgements)
+    return
+
+
+def clean(self):
+    """Raise warning that cleaning is not needed for the OMNI2 data.
+
+    Note
+    ----
+    Supports 'clean', 'dusty', 'dirty' in the sense that it prints
+    a message noting there is no cleaning.
+    'None' is also supported as it signifies no cleaning.
+
+    Routine is called by pysat, and not by the end user directly.
+
+    """
+    pysat.logger.warning(
+        "No cleaning available for the Madrigal geophysical indices")
+
+    return
+
+
+# ----------------------------------------------------------------------------
+# Instrument functions
+#
+# Use the default Madrigal and pysat methods
+file_cadence = madrigal_end - madrigal_start
+two_digit_year_break = 50
+
+# Set the download routine
+download = functools.partial(general.download,
+                             inst_code=str(madrigal_inst_code),
+                             kindat=madrigal_tag[''][''])
+
+# Set the list routine
+list_files = functools.partial(general.list_files,
+                               supported_tags=supported_tags,
+                               file_cadence=file_cadence,
+                               two_digit_year_break=two_digit_year_break)
+
+# Set list_remote_files routine
+list_remote_files = functools.partial(general.list_remote_files,
+                                      supported_tags=remote_tags,
+                                      inst_code=madrigal_inst_code,
+                                      kindats=madrigal_tag,
+                                      two_digit_year_break=two_digit_year_break)
+
+
+def load(fnames, tag='', inst_id=''):
+    """Load the Madrigal Dst data.
+
+    Parameters
+    -----------
+    fnames : list
+        List of filenames
+    tag : str
+        tag name used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself. (default='')
+    inst_id : str
+        Instrument ID used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself. (default='')
+
+    Returns
+    --------
+    data : pds.DataFrame
+        Object containing IMF data
+    meta : pysat.Meta
+        Object containing metadata such as column names and units
+
+    Raises
+    ------
+    ValueError
+        Unexpected time variable names
+
+    """
+    # Cycle through all the filenames, getting the desired start and stop times
+    fstart = None
+    fstop = None
+    for fname_date in fnames:
+        # Split the date from the filename
+        fname = fname_date[:-11]
+        fdate = dt.datetime.strptime(fname_date[-10:], '%Y-%m-%d')
+        fstop = fdate
+
+        if fstart is None:
+            fstart = fdate
+
+    fstop += dt.timedelta(days=1)
+
+    # There is only one file for this Instrument
+    data, meta = general.load([fname], tag=tag, inst_id=inst_id)
+
+    # Select the data for the desired time period
+    data = data[fstart:fstop]
+
+    return data, meta

--- a/pysatMadrigal/instruments/madrigal_pandas.py
+++ b/pysatMadrigal/instruments/madrigal_pandas.py
@@ -77,7 +77,7 @@ tags = dict()
 pandas_format = True
 
 # Pandas-style data that requires special support
-excluded_tags = ['8105', '180', '211']
+excluded_tags = ['8105', '180', '211', '120']
 
 # Assign only tags with pysat-compatible file format strings
 pandas_codes = general.known_madrigal_inst_codes(pandas_format=True)
@@ -100,9 +100,8 @@ supported_tags = {ss: {tag: general.madrigal_file_format_str(tag)
 
 # ----------------------------------------------------------------------------
 # Instrument test attributes
-tag_dates = {'120': dt.datetime(1963, 11, 27), '170': dt.datetime(1998, 7, 1),
-             '210': dt.datetime(1950, 1, 1), '212': dt.datetime(1957, 1, 1),
-             '7800': dt.datetime(2009, 11, 10)}
+tag_dates = {'170': dt.datetime(1998, 7, 1), '210': dt.datetime(1950, 1, 1),
+             '212': dt.datetime(1957, 1, 1), '7800': dt.datetime(2009, 11, 10)}
 _test_dates = {'': {tag: tag_dates[tag] if tag in tag_dates.keys()
                     else tag_dates['7800'] for tag in tags.keys()}}
 _test_download = {'': {tag: True for tag in tags.keys()}}

--- a/pysatMadrigal/instruments/madrigal_pandas.py
+++ b/pysatMadrigal/instruments/madrigal_pandas.py
@@ -77,7 +77,7 @@ tags = dict()
 pandas_format = True
 
 # Pandas-style data that requires special support
-excluded_tags = ['8105', '180', '211', '120']
+excluded_tags = ['120', '180', '210', '211', '212', '8105']
 
 # Assign only tags with pysat-compatible file format strings
 pandas_codes = general.known_madrigal_inst_codes(pandas_format=True)
@@ -100,8 +100,7 @@ supported_tags = {ss: {tag: general.madrigal_file_format_str(tag)
 
 # ----------------------------------------------------------------------------
 # Instrument test attributes
-tag_dates = {'170': dt.datetime(1998, 7, 1), '210': dt.datetime(1950, 1, 1),
-             '212': dt.datetime(1957, 1, 1), '7800': dt.datetime(2009, 11, 10)}
+tag_dates = {'170': dt.datetime(1998, 7, 1), '7800': dt.datetime(2009, 11, 10)}
 _test_dates = {'': {tag: tag_dates[tag] if tag in tag_dates.keys()
                     else tag_dates['7800'] for tag in tags.keys()}}
 _test_download = {'': {tag: True for tag in tags.keys()}}

--- a/pysatMadrigal/instruments/ngdc_ae.py
+++ b/pysatMadrigal/instruments/ngdc_ae.py
@@ -37,7 +37,7 @@ Examples
     import pysat
     import pysatMadrigal as py_mad
 
-    # Download DMSP data from Madrigal
+    # Download AE data from Madrigal
     aei = pysat.Instrument(inst_module=py_mad.instruments.ngdc_ae)
     aei.download(start=py_mad.instruments.ngdc_ae.madrigal_start,
                  user='Firstname+Lastname', password='email@address.com')

--- a/pysatMadrigal/instruments/ngdc_ae.py
+++ b/pysatMadrigal/instruments/ngdc_ae.py
@@ -25,8 +25,7 @@ routine.
 Warnings
 --------
 The entire data set (1 Jan 1978 through 31 Dec 1987) is provided in a single
-file on Madrigal. The download method will break this file up by year for
-easier access.
+file on Madrigal.
 
 Examples
 --------
@@ -222,12 +221,12 @@ def load(fnames, tag='', inst_id=''):
         # Split the date from the filename
         fname = fname_date[:-11]
         fdate = dt.datetime.strptime(fname_date[-10:], '%Y-%m-%d')
+        fstop = fdate
 
         if fstart is None:
             fstart = fdate
 
-        if fstop is None:
-            fstop = fdate
+    fstop += dt.timedelta(days=1)
 
     # There is only one file for this Instrument
     with h5py.File(fname, 'r') as filed:
@@ -280,7 +279,7 @@ def load(fnames, tag='', inst_id=''):
                                                        day=day)
 
         # Get the data mask
-        dmask = (fdate >= fstart) & (fdate <= fstop)
+        dmask = (fdate >= fstart) & (fdate < fstop)
 
         # Construct the time index
         hour = file_data[dmask]['hour']

--- a/pysatMadrigal/instruments/omni2_imf.py
+++ b/pysatMadrigal/instruments/omni2_imf.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+# Full license can be found in License.md
+# Full author list can be found in .zenodo.json file
+# DOI:10.5281/zenodo.3824979
+# ----------------------------------------------------------------------------
+# -*- coding: utf-8 -*-.
+"""Supports access to OMNI 2 IMF data archieved at Madrigal.
+
+Properties
+----------
+platform
+    'omni2'
+name
+    'imf'
+tag
+    None supported
+inst_id
+    None supported
+
+Note
+----
+Please provide name (user) and email (password) when downloading data with this
+routine.
+
+Glenn Campbell and Bill Rideout completely rebuilt the Madrigal interplanetary
+magnetic field data using data from:
+ftp://nssdcftp.gsfc.nasa.gov/spacecraft_data/omni/.  The old file had
+originally come from Cedar and had gaps even in places where there was data
+available.  This new Madrigal file is based on the Omni 2 data set, described
+at http://nssdc.gsfc.nasa.gov/omniweb/. (4 May 2004, brideout@haystack.mit.edu)
+
+The OMNI data may be directly downloaded using pysatNASA and is now described
+at: https://omniweb.gsfc.nasa.gov/html/ow_data.html
+
+Warnings
+--------
+The entire data set (27 Nov 1963 through 3 Jun 2019) is provided in a single
+file on Madrigal. The download method will break this file up by year for
+easier access.
+
+Examples
+--------
+::
+
+
+    import datetime as dt
+    import pysat
+    import pysatMadrigal as py_mad
+
+    # Download IMF data from Madrigal
+    imf = pysat.Instrument(inst_module=py_mad.instruments.omni2_imf)
+    imf.download(start=py_mad.instruments.omni2_imf.madrigal_start,
+                 user='Firstname+Lastname', password='email@address.com')
+    imf.load(date=dt.datetime(1981, 1, 1))
+
+"""
+
+import datetime as dt
+import functools
+
+import pysat
+
+from pysatMadrigal.instruments.methods import general
+
+# ----------------------------------------------------------------------------
+# Instrument attributes
+
+platform = 'omni2'
+name = 'imf'
+tags = {'': ''}
+inst_ids = {'': list(tags.keys())}
+pandas_format = True
+
+# Madrigal tags and limits
+madrigal_inst_code = 120
+madrigal_tag = {'': {'': "30012"}}
+madrigal_start = dt.datetime(1963, 11, 27)
+madrigal_end = dt.datetime(2019, 6, 4)
+
+# Local attributes
+#
+# Need a way to get the filename strings for a particular instrument unless
+# wildcards start working
+supported_tags = {
+    inst_id: {tag: general.madrigal_file_format_str(madrigal_inst_code,
+                                                    verbose=False)
+              for tag in inst_ids[inst_id]} for inst_id in inst_ids.keys()}
+remote_tags = {ss: {kk: supported_tags[ss][kk].format(file_type='hdf5')
+                    for kk in inst_ids[ss]} for ss in inst_ids.keys()}
+
+# ----------------------------------------------------------------------------
+# Instrument test attributes
+
+_test_dates = {inst_id: {tag: madrigal_start for tag in inst_ids[inst_id]}
+               for inst_id in inst_ids.keys()}
+_test_download = {inst_id: {tag: True for tag in inst_ids[inst_id]}
+                  for inst_id in inst_ids.keys()}
+_clean_warn = {inst_id: {tag: {clvl: [('logger', 'WARN',
+                                       "No cleaning available", clvl)]
+                               for clvl in ['clean', 'dusty', 'dirty']}
+                         for tag in inst_ids[inst_id]}
+               for inst_id in inst_ids.keys()}
+
+# ----------------------------------------------------------------------------
+# Instrument methods
+
+
+def init(self):
+    """Initialize the Instrument object in support of Madrigal access.
+
+    Parameters
+    ----------
+    kindat : str
+        Madrigal instrument experiment code(s). (default='')
+
+    """
+    # Set the standard pysat attributes
+    self.acknowledgements = ''.join([general.cedar_rules(), '\nFor full ',
+                                     'acknowledgement info, please see: ',
+                                     'https://omniweb.gsfc.nasa.gov/html/',
+                                     'citing.html'])
+    self.references = ' '.join(('J.H. King and N.E. Papitashvili, Solar',
+                                'wind spatial scales in and comparisons',
+                                'of hourly Wind and ACE plasma and',
+                                'magnetic field data, J. Geophys. Res.,',
+                                'Vol. 110, No. A2, A02209,',
+                                '10.1029/2004JA010649.'))
+
+    # Remind the user of the Rules of the Road
+    pysat.logger.info(self.acknowledgements)
+    return
+
+
+def clean(self):
+    """Raise warning that cleaning is not needed for the OMNI2 data.
+
+    Note
+    ----
+    Supports 'clean', 'dusty', 'dirty' in the sense that it prints
+    a message noting there is no cleaning.
+    'None' is also supported as it signifies no cleaning.
+
+    Routine is called by pysat, and not by the end user directly.
+
+    """
+    pysat.logger.warning("No cleaning available for the collected Omni 2 IMF")
+
+    return
+
+
+# ----------------------------------------------------------------------------
+# Instrument functions
+#
+# Use the default Madrigal and pysat methods
+file_cadence = madrigal_end - madrigal_start
+two_digit_year_break = 50
+
+# Set the download routine
+download = functools.partial(general.download,
+                             inst_code=str(madrigal_inst_code),
+                             kindat=madrigal_tag[''][''])
+
+# Set the list routine
+list_files = functools.partial(general.list_files,
+                               supported_tags=supported_tags,
+                               file_cadence=file_cadence,
+                               two_digit_year_break=two_digit_year_break)
+
+# Set list_remote_files routine
+list_remote_files = functools.partial(general.list_remote_files,
+                                      supported_tags=remote_tags,
+                                      inst_code=madrigal_inst_code,
+                                      kindats=madrigal_tag,
+                                      two_digit_year_break=two_digit_year_break)
+
+
+def load(fnames, tag='', inst_id=''):
+    """Load the OMNI2 IMF data.
+
+    Parameters
+    -----------
+    fnames : list
+        List of filenames
+    tag : str
+        tag name used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself. (default='')
+    inst_id : str
+        Instrument ID used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself. (default='')
+
+    Returns
+    --------
+    data : pds.DataFrame
+        Object containing IMF data
+    meta : pysat.Meta
+        Object containing metadata such as column names and units
+
+    Raises
+    ------
+    ValueError
+        Unexpected time variable names
+
+    """
+    # Cycle through all the filenames, getting the desired start and stop times
+    fstart = None
+    fstop = None
+    for fname_date in fnames:
+        # Split the date from the filename
+        fname = fname_date[:-11]
+        fdate = dt.datetime.strptime(fname_date[-10:], '%Y-%m-%d')
+        fstop = fdate
+
+        if fstart is None:
+            fstart = fdate
+
+    fstop += dt.timedelta(days=1)
+
+    # There is only one file for this Instrument
+    data, meta = general.load([fname], tag=tag, inst_id=inst_id)
+
+    # Test to see if there is data beyond the expected file end
+    if data.index[-1] > madrigal_end:
+        pysat.logger.critical(''.join(['There is data beyond ',
+                                       '{:}'.format(madrigal_end), ' in the ',
+                                       'Omni2 IMF file, please notify the ',
+                                       'pysatMadrigal developers so that they ',
+                                       'can update this Instrument']))
+
+    # Select the data for the desired time period
+    data = data[fstart:fstop]
+
+    return data, meta


### PR DESCRIPTION
# Description

Addresses #91 by creating instrument sub-modules for the remaining madrigal index files.

# Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality or documentation)
- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

```
import pysat
import pysatMadrigal as pymad

dst = pysat.Instrument(inst_module=pymad.instruments.madrigal_dst, user='User Name', password='your email')
dst.download(start=pymad.instruments.madrigal_dst.madrigal_start)
dst.load(1981, 1)

# Repeat for the madrigal_geoind and omni2_imf Instruments
```

## Test Configuration
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the
release checklist on the pysat wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
